### PR TITLE
Reduce timeout to 45 minutes instead of 360 minutes

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -27,3 +27,4 @@ jobs:
       run: mvn -B clean verify
       env:
         CI: false
+    timeout-minutes: 45


### PR DESCRIPTION
the tests usually take 8 minutes to run so 6 hours is ridiculously excessive, especially when we have a limited amount of testing time per month.