### PR TITLE
Fixes aodn/backlog#2345 - disable concurrent branch builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,10 @@
 pipeline {
     agent none
 
+    options {
+        disableConcurrentBuilds()
+    }
+
     stages {
         stage('container') {
             agent {


### PR DESCRIPTION
Apparently the workspace for a branch build is shared which causes all sorts of problems.  Thanks @lwgordonimos 