### PR TITLE
Make UserActionAudit constructor get auth details itself

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/audit/UserActionAudit.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/audit/UserActionAudit.java
@@ -9,6 +9,8 @@ import javax.persistence.*;
 import java.sql.Timestamp;
 import java.util.Objects;
 
+import static org.springframework.security.core.context.SecurityContextHolder.getContext;
+
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
@@ -54,10 +56,6 @@ public class UserActionAudit {
     }
 
     public UserActionAudit(String operation, String details) {
-        auditTime = new Timestamp(System.currentTimeMillis());
-        this.operation = operation;
-        this.username = null;
-        this.requestId = ThreadContext.get("requestId");
-        this.details = details;
+        this(operation, details, getContext().getAuthentication());
     }
 }


### PR DESCRIPTION
Noticed that where the UserActionAudit is being called we've been using the constructor that doesn't take an Authentication object, which means that user isn't being stored. This change makes that constructor try to retrieve authentication from the context (```getContext()``` is guaranteed to never return null).