### PR TITLE
Fix various build issues

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,15 +9,16 @@ pipeline {
         stage('container') {
             agent {
                 dockerfile {
-                    args '-v ${HOME}/.m2:/home/builder/.m2 -v ${HOME}/bin:${HOME}/bin'
+                    args '-v ${HOME}/.m2:/home/builder/.m2 -v ${HOME}/.cache:/home/builder/.cache -v ${HOME}/bin:${HOME}/bin'
                     additionalBuildArgs '--build-arg BUILDER_UID=$(id -u)'
                 }
             }
             stages {
                 stage('clean') {
                     steps {
+                        sh 'rm -rf ui/node api/target'
                         sh 'git reset --hard'
-                        sh 'git clean -xffd'
+                        sh 'git clean -xffd -e ui/node_modules'
                     }
                 }
                 stage('set_version_build') {

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <node.version>v12.18.3</node.version>
-        <yarn.version>v1.12.1</yarn.version>
+        <yarn.version>v1.22.10</yarn.version>
         <frontend-maven-plugin.version>1.10.0</frontend-maven-plugin.version>
     </properties>
 


### PR DESCRIPTION
* use jenkins global yarn cache to speed up builds
* leave node_modules alone when cleaning workspace 
* use more recent version of yarn
* lock package versions selected for consistent builds