### PR TITLE
Allow node_modules directory to be specified on the command line

### DIFF
--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -41,7 +41,7 @@
                         </goals>
                         <phase>generate-resources</phase>
                         <configuration>
-                            <arguments>install --network-timeout 1000000</arguments>
+                            <arguments>install --network-timeout 1000000 --modules-folder ${yarn.modules-folder}</arguments>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
```
mvn clean package -Dyarn.modules-folder=/tmp/node_modules
```