### PR TITLE
Make global interceptor work for all api paths

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/config/WebMvcConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/config/WebMvcConfig.java
@@ -34,7 +34,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(globalRequestInterceptor)
-            .addPathPatterns("/api/**/");
+            .addPathPatterns("/api/**");
     }
 
     @Override


### PR DESCRIPTION
not just ones ending in a slash (eg, .csv ones)