### PR TITLE
Fix display of site/observable items attributes

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/ObservableItem.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/ObservableItem.java
@@ -97,7 +97,7 @@ public class ObservableItem {
 
     @Basic
     @Column(name = "obs_item_attribute", columnDefinition = "jsonb")
-    @Schema(title = "Attributes", accessMode = Schema.AccessMode.READ_ONLY)
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
     @Type(type = "jsonb")
     private Map<String, String> obsItemAttribute;
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/Site.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/Site.java
@@ -99,8 +99,8 @@ public class Site {
 
     @Column(name = "site_attribute", columnDefinition = "jsonb")
     @Type(type = "jsonb")
-    @Schema(title = "Attributes", accessMode = Schema.AccessMode.READ_ONLY)
-    private Map<String, Object> siteAttribute;
+    @Schema(accessMode = Schema.AccessMode.READ_ONLY)
+    private Map<String, String> siteAttribute;
 
     @Basic
     @Column(name = "is_active")

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/SiteTestData.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/SiteTestData.java
@@ -37,7 +37,7 @@ public class SiteTestData {
                    .latitude(-57.5)
                    .location(locationTestData.persistedLocation())
                    .oldSiteCodes(Arrays.asList(new String[] {"SIT01", "SIT02"}))
-                   .siteAttribute(ImmutableMap.<String, Object>builder()
+                   .siteAttribute(ImmutableMap.<String, String>builder()
                            .put("State", "Graham Land Antarctica")
                            .put("Country", "Antarctica")
                            .put("ProxCountry", "Antarctica")


### PR DESCRIPTION
Adding a title breaks react json-schema forms - it uses it for all key names.  Also, siteAttribute must be a <String, String>Map to be rendered properly.

Before:

![image](https://user-images.githubusercontent.com/1860215/102034184-8617b980-3e11-11eb-96f5-1df6b3dd8e5c.png)


After:

![image](https://user-images.githubusercontent.com/1860215/102034149-68e2eb00-3e11-11eb-952b-80a0f364a8f6.png)


Can't see anyway of specifying a title at the moment.  Still looking...