### PR TITLE
Fix duplicates being returned when validating jobs

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/SecUser.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/SecUser.java
@@ -73,7 +73,7 @@ public class  SecUser implements Serializable {
 
     @NotAudited
     @JsonIgnore
-    @ManyToMany(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @ManyToMany(fetch = FetchType.EAGER)
     @JoinTable(
         name = "sec_user_roles",
         joinColumns = @JoinColumn(name = "sec_user_id", foreignKey = @ForeignKey(name = "FK_USER_SEC_ROLE")),

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedJobLog.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedJobLog.java
@@ -2,12 +2,7 @@ package au.org.aodn.nrmn.restapi.model.db;
 
 import au.org.aodn.nrmn.restapi.model.db.enums.StagedJobEventType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
@@ -29,6 +24,7 @@ public class StagedJobLog {
     @JsonIgnore
     @JoinColumn(name = "staged_job_id", referencedColumnName = "id", nullable = false,
         foreignKey = @ForeignKey(name = "staged_job_log_staged_job_id_fkey"))
+    @ToString.Exclude
     private StagedJob stagedJob;
 
     @Column(name = "event_time", columnDefinition = "timestamp with time zone", nullable = false)

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedRow.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedRow.java
@@ -114,6 +114,7 @@ public class StagedRow implements Serializable {
     @JsonIgnore
     @ManyToOne()
     @JoinColumn(foreignKey = @ForeignKey(name = "staged_row_staged_job_id_fkey"))
+    @ToString.Exclude
     private StagedJob stagedJob;
 
     @Column(name = "created", columnDefinition = "timestamp with time zone", nullable = false)

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/StagedRowRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/StagedRowRepository.java
@@ -17,9 +17,6 @@ import java.util.Optional;
 public interface StagedRowRepository extends JpaRepository<StagedRow, Long>, JpaSpecificationExecutor<StagedRow> {
     Optional<StagedRow> findById(Long id);
 
-    @Query("SELECT r FROM StagedRow r WHERE  r.stagedJob.reference = :reference")
-    List<StagedRow> findRowsByReference(@Param("reference") String ref);
-
     @Query("SELECT r FROM StagedRow r WHERE  r.stagedJob.id = :jobId")
     List<StagedRow> findRowsByJobId(@Param("jobId") Long jobId);
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -40,11 +40,10 @@ public class ValidationProcess extends ValidatorHelpers {
 
 
     public ValidationResponse process(StagedJob job) {
-        val stagedRows = rowRepo.findRowsByReference(job.getReference());
         val rawValidators = preProcess.getRawValidators(job);
         val reducer = new MonoidRowValidation<Seq<Tuple2<String, Object>>>(Seq.empty(), Monoids.<Tuple2<String, Object>>seqConcat());
         val rowChecks =
-                stagedRows.stream()
+                job.getRows().stream()
                         .map(row -> preProcess.validate(row, rawValidators))
                         .collect(Collectors.toList());
         val preCheck = rowChecks.stream().reduce(reducer.zero(), reducer::apply);

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/SecUserTestData.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/SecUserTestData.java
@@ -25,6 +25,8 @@ public class SecUserTestData {
     @Autowired
     SecRoleRepository roleRepo;
 
+    private int userNo = 0;
+
     public SecUser persistedUser() {
         val user = defaultBuilder().build();
         return userRepo.saveAndFlush(user);
@@ -34,8 +36,8 @@ public class SecUserTestData {
         val role = roleTestData.persistedRole();
 
         return SecUser.builder()
-                .email("builder@test.com")
-                .fullName("IT-user")
+                .email("builder" + ++userNo + "@test.com")
+                .fullName("IT-user" + userNo)
                 .hashedPassword("pwdhashed123")
                 .roles(new HashSet<>(Collections.singletonList(role)))
                 .status(SecUserStatus.ACTIVE);

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/StagedJobIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/StagedJobIT.java
@@ -16,6 +16,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
@@ -43,7 +44,7 @@ class StagedJobIT {
         val stagedJob = stagedJobTestData.persistedStagedJob();
         entityManager.clear();
         val retrievedStagedJob = stagedJobRepository.findById(stagedJob.getId()).get();
-         assertEquals(stagedJob, retrievedStagedJob);
+        assertEquals(stagedJob.toString(), retrievedStagedJob.toString());
         assertThat(retrievedStagedJob.getCreated().toLocalDateTime(),
                 is(both(greaterThanOrEqualTo(startTime)).and(lessThanOrEqualTo(LocalDateTime.now()))));
         assertThat(retrievedStagedJob.getLastUpdated().toLocalDateTime(),

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/StagedJobLogIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/StagedJobLogIT.java
@@ -43,7 +43,7 @@ class StagedJobLogIT {
         entityManager.clear();
 
         val retrievedStagedJobLog = stagedJobLogRepository.findById(stagedJobLog.getId()).get();
-        assertEquals(stagedJobLog, retrievedStagedJobLog);
+        assertEquals(stagedJobLog.toString(), retrievedStagedJobLog.toString());
         assertThat(retrievedStagedJobLog.getEventTime().toLocalDateTime(),
             is(both(greaterThanOrEqualTo(startTime)).and(lessThanOrEqualTo(LocalDateTime.now()))));
     }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/StagedJobTestData.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/StagedJobTestData.java
@@ -8,6 +8,8 @@ import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.util.Collections;
+
 @Component
 public class StagedJobTestData {
 
@@ -19,20 +21,48 @@ public class StagedJobTestData {
 
     @Autowired
     private ProgramTestData programTestData;
+
     public StagedJob persistedStagedJob() {
         val stagedJob = defaultBuilder().build();
-         stagedJobRepository.saveAndFlush(stagedJob);
-         return stagedJob;
+        stagedJobRepository.saveAndFlush(stagedJob);
+        return stagedJob;
     }
 
     public StagedJobBuilder defaultBuilder() {
         val program = programTestData.persistedProgram();
         val user = userTestData.persistedUser();
         return StagedJob.builder()
-                .program(program)
-                .reference("survey.xls")
-                .source(SourceJobType.INGEST)
-                .creator(user)
-                .status(StatusJobType.STAGED);
+                        .program(program)
+                        .reference("survey.xls")
+                        .source(SourceJobType.INGEST)
+                        .creator(user)
+                        .status(StatusJobType.STAGED)
+                        .isExtendedSize(false)
+                        .rows(Collections.emptyList())
+                        .logs(Collections.emptyList());
     }
+
+    public StagedJob persistedJobWithReference(String reference) {
+        val stagedJob = defaultBuilder()
+                .reference(reference)
+                .build();
+
+        stagedJob.setRows(Collections.singletonList(
+                StagedRow.builder()
+                         .block("1")
+                         .buddy("Nadia")
+                         .code("nte")
+                         .commonName("Blue-throat wrasse")
+                         .date("12/12/2019")
+                         .depth("6")
+                         .direction("0")
+                         .diver("SDL")
+                         .inverts("0")
+                         .stagedJob(stagedJob)
+                         .build())
+        );
+
+        return stagedJobRepository.saveAndFlush(stagedJob);
+    }
+
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcessIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcessIT.java
@@ -1,0 +1,39 @@
+package au.org.aodn.nrmn.restapi.validation.process;
+
+import au.org.aodn.nrmn.restapi.model.db.StagedJobTestData;
+import au.org.aodn.nrmn.restapi.test.PostgresqlContainerExtension;
+import au.org.aodn.nrmn.restapi.test.annotations.WithNoData;
+import lombok.val;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.springframework.test.util.AssertionErrors.assertEquals;
+
+@Testcontainers
+@SpringBootTest
+@ExtendWith(PostgresqlContainerExtension.class)
+@WithNoData
+public class ValidationProcessIT {
+
+    @Autowired
+    private ValidationProcess validationProcess;
+
+    @Autowired
+    private StagedJobTestData stagedJobTestData;
+
+    @Test
+    public void testValidationResultsNotDuplicated() {
+        val stagedJob1 = stagedJobTestData.persistedJobWithReference("ref1.xls");
+        val stagedJob2 = stagedJobTestData.persistedJobWithReference("ref1.xls");
+
+        val response = validationProcess.process(stagedJob2);
+
+        assertEquals("Validation rows size does not equal job rows size", stagedJob2.getRows().size(),
+                response.getRows().size());
+
+    }
+
+}


### PR DESCRIPTION
Validation process was looking up associated rows by reference (file name) so all rows uploaded for that reference (file name) were being included in validation including ones from other jobs.

Also fixed some issues with Integration tests.