### PR TITLE
Cache findbycriteria responses made in a request

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/DiverRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/DiverRepository.java
@@ -2,6 +2,7 @@ package au.org.aodn.nrmn.restapi.repository;
 
 import au.org.aodn.nrmn.restapi.model.db.Diver;
 import au.org.aodn.nrmn.restapi.repository.model.EntityCriteria;
+import au.org.aodn.nrmn.restapi.requestcache.RequestCache;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -21,6 +22,7 @@ public interface DiverRepository extends JpaRepository<Diver, Integer>, JpaSpeci
 
     @Override
     @Query("SELECT d FROM  Diver  d WHERE d.initials = :initials")
+    @RequestCache
     List<Diver> findByCriteria(@Param("initials")String initials);
 
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SiteRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SiteRepository.java
@@ -2,6 +2,7 @@ package au.org.aodn.nrmn.restapi.repository;
 
 import au.org.aodn.nrmn.restapi.model.db.Site;
 import au.org.aodn.nrmn.restapi.repository.model.EntityCriteria;
+import au.org.aodn.nrmn.restapi.requestcache.RequestCache;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +23,7 @@ public interface SiteRepository extends JpaRepository<Site, Integer>, JpaSpecifi
 
     @Override
     @Query("SELECT s FROM Site s WHERE s.siteCode = :code")
+    @RequestCache
     List<Site> findByCriteria(@Param("code") String siteCode);
 
     @Override

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/requestcache/InvocationTarget.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/requestcache/InvocationTarget.java
@@ -1,0 +1,36 @@
+package au.org.aodn.nrmn.restapi.requestcache;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Arrays;
+
+class InvocationTarget {
+
+    private static final String TO_STRING_TEMPLATE = "%s.%s(%s)";
+
+    private final Class targetClass;
+    private final String targetMethod;
+    private final Object[] args;
+
+    InvocationTarget(Class targetClass, String targetMethod, Object[] args) {
+        this.targetClass = targetClass;
+        this.targetMethod = targetMethod;
+        this.args = args;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return EqualsBuilder.reflectionEquals(this, o);
+    }
+
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+
+    @Override
+    public String toString() {
+        return String.format(TO_STRING_TEMPLATE, targetClass.getName(), targetMethod, Arrays.toString(args));
+    }
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/requestcache/RequestCache.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/requestcache/RequestCache.java
@@ -1,0 +1,11 @@
+package au.org.aodn.nrmn.restapi.requestcache;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RequestCache {
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/requestcache/RequestCacheManager.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/requestcache/RequestCacheManager.java
@@ -1,0 +1,24 @@
+package au.org.aodn.nrmn.restapi.requestcache;
+
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.annotation.RequestScope;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@RequestScope(proxyMode = ScopedProxyMode.TARGET_CLASS)
+class RequestCacheManager {
+
+    private final Map<InvocationTarget, Object> cache = new ConcurrentHashMap<>();
+
+    Optional<Object> get(InvocationTarget invocationContext) {
+        return Optional.ofNullable(cache.get(invocationContext));
+    }
+
+    void put(InvocationTarget methodInvocation, Object result) {
+        cache.put(methodInvocation, result);
+    }
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/requestcache/RequestScopeAspect.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/requestcache/RequestScopeAspect.java
@@ -1,0 +1,44 @@
+package au.org.aodn.nrmn.restapi.requestcache;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+@Aspect
+@Component
+class RequestScopeAspect {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RequestScopeAspect.class);
+
+    private final RequestCacheManager requestCacheManager;
+
+    @Autowired
+    RequestScopeAspect(RequestCacheManager requestCacheManager) {
+        this.requestCacheManager = requestCacheManager;
+    }
+
+    @Around("@annotation(au.org.aodn.nrmn.restapi.requestcache.RequestCache)")
+    Object processRequestCache(ProceedingJoinPoint pjp) throws Throwable {
+        InvocationTarget invocationTarget = new InvocationTarget(
+                pjp.getSignature().getDeclaringType(),
+                pjp.getSignature().getName(),
+                pjp.getArgs()
+        );
+        Optional<Object> cachedResult = requestCacheManager.get(invocationTarget);
+        if (cachedResult.isPresent()) {
+            Object result = cachedResult.get();
+            LOGGER.info("Using cached value {}, for invocation: {}", result, invocationTarget);
+            return result;
+        } else {
+            Object methodResult = pjp.proceed();
+            LOGGER.info("Caching result: {}, for invocation: {}", methodResult, invocationTarget);
+            requestCacheManager.put(invocationTarget, methodResult);
+            return methodResult;
+        }
+    }
+}


### PR DESCRIPTION
As per https://okraskat.github.io/caching-per-request-with-spring/

Improves validation performance  for https://github.com/aodn/backlog/issues/2661

Added for Diver and Site only - not expecting any improvement for species.