### PR TITLE
Fix issue running integration tests in github actions

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,6 +14,7 @@
 
     <properties>
         <java.version>1.8</java.version>
+        <testcontainers.version>1.15.2</testcontainers.version>
     </properties>
 
     <dependencies>
@@ -134,13 +135,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.14.3</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.14.3</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -220,7 +221,7 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>localstack</artifactId>
-            <version>1.14.3</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/springdatarest/BeforeCreateLocationValidator.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/springdatarest/BeforeCreateLocationValidator.java
@@ -28,7 +28,7 @@ public class BeforeCreateLocationValidator implements Validator {
 
         if (locationRepository.exists(locationWithNameExample)) {
             errors.rejectValue("locationName", "location.locationName.exists",
-                    "a location with that name already exists");
+                    "A location with that name already exists.");
         }
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/springdatarest/BeforeCreateSiteValidator.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/springdatarest/BeforeCreateSiteValidator.java
@@ -32,7 +32,7 @@ public class BeforeCreateSiteValidator implements Validator {
 
         if (siteRepository.exists(siteWithCodeAndNameExample)) {
             errors.rejectValue("siteName", "site.exists",
-                    "a site with that code and name already exists");
+                    "A site with that code and name already exists.");
         }
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/springdatarest/BeforeSaveSiteValidator.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/springdatarest/BeforeSaveSiteValidator.java
@@ -34,7 +34,7 @@ public class BeforeSaveSiteValidator implements Validator {
 
         if (existingSiteWithCodeAndName.isPresent()
                 && !site.getSiteId().equals(existingSiteWithCodeAndName.get().getSiteId())) {
-            errors.rejectValue("siteName", "site.exists", "a site with that code and name already exists");
+            errors.rejectValue("siteName", "site.exists", "A site with that code and name already exists.");
         }
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/test/PostgresqlContainerExtension.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/test/PostgresqlContainerExtension.java
@@ -4,9 +4,10 @@ import org.junit.jupiter.api.extension.Extension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /* Adds a persistent postgres container for use in tests
- * Only started if running a test that references it and then only shut down 
+ * Only started if running a test that references it and then only shut down
  * when the jvm is shut down so it can be reused in multiple tests */
 
 public class PostgresqlContainerExtension implements Extension {
@@ -15,7 +16,10 @@ public class PostgresqlContainerExtension implements Extension {
 
     static {
         try {
-            PostgreSQLContainer container = new PostgreSQLContainer("mdillon/postgis:9.6");
+            DockerImageName postgisImage = DockerImageName
+                    .parse("mdillon/postgis:9.6")
+                    .asCompatibleSubstituteFor("postgres");
+            PostgreSQLContainer container = new PostgreSQLContainer(postgisImage);
             container.start();
             System.setProperty("DB_URL", container.getJdbcUrl());
             System.setProperty("DB_USERNAME", container.getUsername());

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/test/PostgresqlContainerExtension.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/test/PostgresqlContainerExtension.java
@@ -1,6 +1,8 @@
 package au.org.aodn.nrmn.restapi.test;
 
 import org.junit.jupiter.api.extension.Extension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.PostgreSQLContainer;
 
 /* Adds a persistent postgres container for use in tests
@@ -9,11 +11,17 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PostgresqlContainerExtension implements Extension {
 
+    private static final Logger logger = LoggerFactory.getLogger(PostgresqlContainerExtension.class);
+
     static {
-        PostgreSQLContainer container = new PostgreSQLContainer("mdillon/postgis:9.6");
-        container.start();
-        System.setProperty("DB_URL", container.getJdbcUrl());
-        System.setProperty("DB_USERNAME", container.getUsername());
-        System.setProperty("DB_PASSWORD", container.getPassword());
+        try {
+            PostgreSQLContainer container = new PostgreSQLContainer("mdillon/postgis:9.6");
+            container.start();
+            System.setProperty("DB_URL", container.getJdbcUrl());
+            System.setProperty("DB_USERNAME", container.getUsername());
+            System.setProperty("DB_PASSWORD", container.getPassword());
+        } catch (Throwable t) {
+            logger.error("Couldn't start postgis container", t);
+        }
     }
 }


### PR DESCRIPTION
- Upgrade to a recent version of testcontainers containing a fix for a recent issue pulling test containers from docker repository.
- Trap and report errors thrown when starting up the postgres test container.  We want tests to fail if the container doesn't startup instead of silently skipping them.
- Fix broken tests not picked up because of these issues.