### PR TITLE
Fix Site > OldSiteCodes not removing or updating correctly

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -255,7 +255,7 @@
         <dependency>
             <groupId>org.modelmapper</groupId>
             <artifactId>modelmapper</artifactId>
-            <version>2.3.0</version>
+            <version>2.3.3</version>
         </dependency>
     </dependencies>
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/config/MappingConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/config/MappingConfig.java
@@ -8,6 +8,8 @@ import org.springframework.context.annotation.Configuration;
 public class MappingConfig {
     @Bean
     public ModelMapper modelMapper() {
-        return new ModelMapper();
+        ModelMapper modelMapper = new ModelMapper();
+        modelMapper.getConfiguration().setCollectionsMergeEnabled(false);
+        return modelMapper;
     }
 }


### PR DESCRIPTION
Upgraded ModelMapper from 2.3.0 to 2.3.3 so to use the option to disable collection merge behaviour.