### PR TITLE
Indicate if species superseded in species search

### DIFF
--- a/ui/src/components/data-entities/EntityContainer.js
+++ b/ui/src/components/data-entities/EntityContainer.js
@@ -9,6 +9,7 @@ const EntityContainer = (props) => (
       {'<< Back to ' + props.name}
     </NavLink>
     <Grid container justify="center">
+      {props.header}
       <Box style={{background: 'white', width: 700}} boxShadow={1} margin={3}>
         <Grid container alignItems="flex-start" direction="row">
           {props.children}
@@ -21,7 +22,8 @@ const EntityContainer = (props) => (
 EntityContainer.propTypes = {
   name: PropTypes.string.isRequired,
   goBackTo: PropTypes.string.isRequired,
-  children: PropTypes.any
+  children: PropTypes.any,
+  header: PropTypes.any
 };
 
 export default EntityContainer;

--- a/ui/src/components/data-entities/EntityEdit.js
+++ b/ui/src/components/data-entities/EntityEdit.js
@@ -160,13 +160,12 @@ const EntityEdit = ({entity, template, clone}) => {
       <LoadingBanner variant={'h5'} msg={`Loading ${entity.name}`} />
     </Grid>
   ) : (
-    <EntityContainer name={entity.name} goBackTo={entity.list.route}>
-      <Grid item>
+    <EntityContainer name={entity.name} goBackTo={entity.list.route} header={entity.showSpeciesSeach && <SpeciesSearch />}>
+      <Grid container direction="row" justify="flex-start" alignItems="center">
         {params.loading ? (
           <CircularProgress size={20} />
         ) : (
           <>
-            {entity.showSpeciesSeach && <SpeciesSearch />}
             <Box pt={2} px={6.25} pb={6}>
               {errors.length > 0 ? (
                 <Box pt={2}>

--- a/ui/src/components/search/SpeciesSearch.js
+++ b/ui/src/components/search/SpeciesSearch.js
@@ -1,8 +1,10 @@
 import React from 'react';
-// import {PropTypes} from 'prop-types';
+import clsx from 'clsx';
 import {AppBar, Box, Button, Divider, Grid, Tab, Tabs, TextField, Typography} from '@material-ui/core';
 import {DataGrid} from '@material-ui/data-grid';
 import {Search} from '@material-ui/icons';
+import Alert from '@material-ui/lab/Alert';
+import makeStyles from '@material-ui/core/styles/makeStyles';
 
 import TabPanel from '../containers/TabPanel';
 
@@ -10,19 +12,36 @@ import {useDispatch, useSelector} from 'react-redux';
 import {searchRequested} from '../data-entities/form-reducer';
 import {setFields} from '../data-entities/middleware/entities';
 
+const useStyles = makeStyles({
+  root: {
+    '& .superseded': {
+      color: '#999999'
+    }
+  }
+});
+
 const columns = [
-  {field: 'species', headerName: 'Species', width: 180},
-  {field: 'genus', headerName: 'Genus', width: 180},
-  {field: 'family', headerName: 'Family', width: 180},
-  {field: 'order', headerName: 'Order', width: 180},
-  {field: 'class', headerName: 'Class', width: 180},
-  {field: 'phylum', headerName: 'Phylum', width: 180}
+  {
+    field: 'species',
+    headerName: 'Species',
+    flex: 2,
+    cellClassName: (params) =>
+      clsx('root', {
+        superseded: params.row.supersededBy
+      })
+  },
+  {field: 'genus', headerName: 'Genus', flex: 1},
+  {field: 'family', headerName: 'Family', flex: 1},
+  {field: 'order', headerName: 'Order', flex: 1},
+  {field: 'class', headerName: 'Class', flex: 1},
+  {field: 'phylum', headerName: 'Phylum', flex: 1}
 ];
 
 const SpeciesSearch = () => {
-  // const classes = useStyles();
+  const classes = useStyles();
   const [value, setValue] = React.useState(0);
   const [searchTerm, setSearchTerm] = React.useState('');
+  const [warning, setWarning] = React.useState(null);
   const loading = useSelector((state) => state.form.loading);
   const searchResults = useSelector((state) => state.form.searchResults);
 
@@ -33,38 +52,17 @@ const SpeciesSearch = () => {
 
   const dispatch = useDispatch();
   return (
-    <>
-      <Box ml={6}>
+    <Box ml={6} style={{background: 'white'}} boxShadow={1} margin={3} width={1000}>
+      <Box pl={6}>
         <h1>Species Lookup</h1>
       </Box>
       <AppBar position="static">
         <Tabs value={value} onChange={handleChange}>
-          <Tab label="NRMN" style={{minWidth: '50%'}} />
           <Tab label="WoRMS" style={{minWidth: '50%', textTransform: 'none'}} />
+          <Tab label="NRMN" style={{minWidth: '50%'}} />
         </Tabs>
       </AppBar>
       <TabPanel value={value} index={0}>
-        <Typography variant="subtitle2">Scientific Name</Typography>
-        <Grid container direction="row" alignItems="center">
-          <Grid item xs={5}>
-            <TextField fullWidth onChange={(e) => setSearchTerm(e.target.value)} />
-          </Grid>
-          <Grid item xs={1}></Grid>
-          <Grid item xs={3}>
-            <Button
-              variant="contained"
-              disabled={loading || !(searchTerm?.length > 3)}
-              startIcon={<Search></Search>}
-              onClick={() => dispatch(searchRequested({searchType: 'NRMN', species: searchTerm}))}
-              color="primary"
-              style={{textTransform: 'none'}}
-            >
-              Search NRMN
-            </Button>
-          </Grid>
-        </Grid>
-      </TabPanel>
-      <TabPanel value={value} index={1}>
         <Typography variant="subtitle2">Scientific Name</Typography>
         <Grid container direction="row" alignItems="center">
           <Grid item xs={5}>
@@ -85,21 +83,59 @@ const SpeciesSearch = () => {
           </Grid>
         </Grid>
       </TabPanel>
+      {warning ? (
+        <Box pt={2}>
+          <Alert severity="warning" variant="filled">
+            {warning}
+          </Alert>
+        </Box>
+      ) : null}
+      <TabPanel value={value} index={1}>
+        <Typography variant="subtitle2">Scientific Name</Typography>
+        <Grid container direction="row" alignItems="center">
+          <Grid item xs={5}>
+            <TextField fullWidth onChange={(e) => setSearchTerm(e.target.value)} />
+          </Grid>
+          <Grid item xs={1}></Grid>
+          <Grid item xs={3}>
+            <Button
+              variant="contained"
+              disabled={loading || !(searchTerm?.length > 3)}
+              startIcon={<Search></Search>}
+              onClick={() => dispatch(searchRequested({searchType: 'NRMN', species: searchTerm}))}
+              color="primary"
+              style={{textTransform: 'none'}}
+            >
+              Search NRMN
+            </Button>
+          </Grid>
+        </Grid>
+      </TabPanel>
       {loading || searchResults !== null ? (
-        <div style={{height: 320, width: '100%'}}>
+        <div style={{height: 640, backgroundColor: 'white'}}>
           <DataGrid
+            className={classes.root}
             density="compact"
+            style={{fontSize: 4}}
             rows={searchResults}
             columns={columns}
             autoPageSize={true}
             loading={loading}
-            onRowClick={(params) => dispatch(setFields(params))}
+            onRowClick={(params) => {
+              const supersededBy = params.row.supersededBy;
+              if (supersededBy) {
+                setWarning(`This species has been superseded by ${supersededBy}`);
+              } else {
+                setWarning();
+                dispatch(setFields(params));
+              }
+            }}
           />
         </div>
       ) : (
         <Divider />
       )}
-    </>
+    </Box>
   );
 };
 export default SpeciesSearch;


### PR DESCRIPTION

Superseded species names appear slightly greyer to other search results and clicking them will not autofill the form but display a warning containing the superseded name. 

Switched the order of the NRMN and WoRMS search so that WoRMS is now the default.

Also made the search component much wider and taller to avoid scrolling.