### PR TITLE
Disable WormsService test

### DIFF
--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/WormsServiceIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/WormsServiceIT.java
@@ -1,7 +1,7 @@
 package au.org.aodn.nrmn.restapi.service;
 
 import au.org.aodn.nrmn.restapi.service.model.SpeciesRecord;
-import org.junit.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -13,7 +13,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 public class WormsServiceIT {
 
-    @Test @Ignore
+    @Test @Disabled
     public void partialSearchReturnsResults() {
         WebClient wormsClient = WebClient.create("https://www.marinespecies.org/rest");
         WormsService wormsService = new WormsService(wormsClient);


### PR DESCRIPTION
We shouldn't fail builds because external service is down

```
[INFO] Running au.org.aodn.nrmn.restapi.service.WormsServiceIT
[WARNING] Tests run: 1, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 0.001 s - in au.org.aodn.nrmn.restapi.service.WormsServiceIT
```