### PR TITLE
Observable Item Edit: Prevent circular supersededby

### DIFF
--- a/ui/src/components/data-entities/EntityEdit.js
+++ b/ui/src/components/data-entities/EntityEdit.js
@@ -116,7 +116,7 @@ const EntityEdit = ({entity, template, clone}) => {
         ]
       };
     } else if (key === 'supersededBy') {
-      uiSchema[key] = {'ui:field': 'searchInput'};
+      uiSchema[key] = {'ui:field': 'searchInput', exclude: 'observableItemName'};
     } else if (item.format === 'double') {
       uiSchema[key] = {'ui:field': 'double'};
     } else if (item.type === 'boolean') {

--- a/ui/src/components/data-entities/customWidgetFields/SearchInput.js
+++ b/ui/src/components/data-entities/customWidgetFields/SearchInput.js
@@ -6,17 +6,18 @@ import {setField} from '../middleware/entities';
 import {PropTypes} from 'prop-types';
 import {searchRequested} from '../form-reducer';
 
-const SearchInput = ({schema, name}) => {
+const SearchInput = ({schema, name, uiSchema}) => {
   const dispatch = useDispatch();
 
   const value = useSelector((state) => state.form.data[name]) ?? '';
+  const exclude = useSelector((state) => state.form.data[uiSchema.exclude]) ?? '';
   const searchResults = useSelector((state) => state.form.searchResults);
 
   return (
     <>
       <Typography variant="subtitle2">{schema.title}</Typography>
       <Autocomplete
-        options={searchResults?.map((i) => i.species) ?? []}
+        options={searchResults?.map((i) => i.species).filter((f) => f !== exclude) ?? []}
         freeSolo
         defaultValue={value}
         onSelect={(e) => {


### PR DESCRIPTION
Prevents the supersededBy field from autocompleting with the same observable item name.

http://nrmn-fix-circular-autocomplete.dev.aodn.org.au/