### PR TITLE
Species search: Prevent ctrl-c from highlighting and copying the entire row.

### DIFF
--- a/ui/src/components/search/SpeciesSearch.js
+++ b/ui/src/components/search/SpeciesSearch.js
@@ -53,7 +53,7 @@ const SpeciesSearch = () => {
 
   const dispatch = useDispatch();
   return (
-    <Box ml={6} style={{background: 'white'}} boxShadow={1} margin={3} width={1000}>
+    <Box ml={6} style={{background: 'white'}} boxShadow={1} margin={3} width="80%">
       <Box pl={6} py={2}>
         <Typography variant="h4">Species Lookup</Typography>
       </Box>
@@ -123,6 +123,7 @@ const SpeciesSearch = () => {
         <div style={{height: 640, backgroundColor: 'white'}}>
           <DataGrid
             className={classes.root}
+            disableSelectionOnClick
             density="compact"
             style={{fontSize: 4}}
             rows={searchResults}


### PR DESCRIPTION
By default, just selecting the species and using 'ctrl-c' keyboard shortcut will select and copy the entire row.

Stack available at http://nrmn-fix-species-search-copy-paste.dev.aodn.org.au