### PR TITLE
Add limited paging to worms/nrmn search

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SpeciesController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SpeciesController.java
@@ -35,14 +35,15 @@ public class SpeciesController {
     @GetMapping
     public List<SpeciesDto> findSpecies(@RequestParam("species") String speciesName,
                                         @RequestParam("includeSuperseded") Boolean includeSuperseded,
-                                        SpeciesSearchType searchType) {
+                                        SpeciesSearchType searchType,
+                                        @RequestParam(defaultValue = "0") int page) {
         if (searchType.equals(WORMS)) {
-            return wormsService.partialSearch(speciesName)
+            return wormsService.partialSearch(page, speciesName)
             .stream()
             .map(aphiaRef -> mapper.map(aphiaRef, SpeciesDto.class))
             .collect(Collectors.toList());
         } else {
-            return observableItemRepository.fuzzySearch(PageRequest.of(0, 50), speciesName, includeSuperseded)
+            return observableItemRepository.fuzzySearch(PageRequest.of(page, 50), speciesName, includeSuperseded)
             .stream()
             .map(observableItem -> mapper.map(observableItem, SpeciesDto.class))
             .collect(Collectors.toList());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/WormsService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/WormsService.java
@@ -26,11 +26,12 @@ public class WormsService {
         this.wormsClient = wormsClient;
     }
 
-    public List<SpeciesRecord> partialSearch(String searchTerm) {
+    public List<SpeciesRecord> partialSearch(int page, String searchTerm) {
         Mono<SpeciesRecord[]> response = wormsClient
                 .get().uri(uriBuilder ->
                         uriBuilder.path("/AphiaRecordsByName")
                                   .pathSegment("%" + removeTrailingJunk(searchTerm))
+                                  .queryParam("offset", page * 50 + 1)
                                   .build())
                 .retrieve()
                 .bodyToMono(SpeciesRecord[].class);

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/WormsServiceIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/WormsServiceIT.java
@@ -17,7 +17,7 @@ public class WormsServiceIT {
     public void partialSearchReturnsResults() {
         WebClient wormsClient = WebClient.create("https://www.marinespecies.org/rest");
         WormsService wormsService = new WormsService(wormsClient);
-        List<SpeciesRecord> results = wormsService.partialSearch("Paratrachichthys trailli");
+        List<SpeciesRecord> results = wormsService.partialSearch(0, "Paratrachichthys trailli");
         assertThat(results.isEmpty(), is(false));
     }
 


### PR DESCRIPTION
Restricted by functionality available in worms.  Page size is set to 50 and we can't get total number of matching records.