### PR TITLE
aodn/backlog#3042  - Speed up ingestion

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -3,14 +3,11 @@ package au.org.aodn.nrmn.restapi.service;
 import au.org.aodn.nrmn.restapi.model.db.*;
 import au.org.aodn.nrmn.restapi.model.db.enums.StatusJobType;
 import au.org.aodn.nrmn.restapi.repository.*;
-import au.org.aodn.nrmn.restapi.util.OptionalUtil;
 import au.org.aodn.nrmn.restapi.validation.StagedRowFormatted;
 import cyclops.data.tuple.Tuple2;
 import cyclops.data.tuple.Tuple4;
 import lombok.val;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Example;
 import org.springframework.stereotype.Service;
 import software.amazon.awssdk.utils.ImmutableMap;
@@ -79,12 +76,9 @@ public class SurveyIngestionService {
     public SurveyMethod getSurveyMethod(Survey survey, StagedRowFormatted stagedRow) {
         boolean surveyNotDone = stagedRow.getCode().toLowerCase().equals("snd");
         Method method = entityManager.getReference(Method.class, stagedRow.getMethod());
-        val surveyMethodExample = SurveyMethod.builder().survey(survey).method(method).blockNum(stagedRow.getBlock())
+        val surveyMethod = SurveyMethod.builder().survey(survey).method(method).blockNum(stagedRow.getBlock())
                 .surveyNotDone(surveyNotDone).build();
-        return surveyMethodRepository
-                .findBySurveyIdMethodIdBlockNum(surveyMethodExample.getSurvey().getSurveyId(),
-                        surveyMethodExample.getMethod().getMethodId(), surveyMethodExample.getBlockNum())
-                .orElseGet(() -> surveyMethodRepository.save(surveyMethodExample));
+        return surveyMethodRepository.save(surveyMethod);
     }
 
     public List<Observation> getObservations(SurveyMethod surveyMethod, StagedRowFormatted stagedRow) {

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.platform=postgres
 spring.datasource.url=jdbc:postgresql://localhost:5432/nrmn_dev?reWriteBatchedInserts=true
 spring.datasource.username=nrmn_dev
 spring.datasource.password=nrmn_dev
-spring.jpa.show-sql=false
+spring.jpa.show-sql=true
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true

--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -4,7 +4,7 @@ spring.datasource.platform=postgres
 spring.datasource.url=jdbc:postgresql://localhost:5432/nrmn_dev?reWriteBatchedInserts=true
 spring.datasource.username=nrmn_dev
 spring.datasource.password=nrmn_dev
-spring.jpa.show-sql=true
+spring.jpa.show-sql=false
 spring.jpa.generate-ddl=false
 spring.jpa.hibernate.ddl-auto=none
 spring.jpa.properties.hibernate.jdbc.lob.non_contextual_creation=true


### PR DESCRIPTION
Ingest by survey/survey method so that we only have to look up survey/survey method once
And don't use find by example for looking up measures as this doesn't use the cache.  FindById makes more sense anyway.

Need to revisit ingestion tests as they don't make sense now after refactoring.