### PR TITLE
Include unsized invert observations when ingesting staged job

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -125,8 +125,7 @@ public class SurveyIngestionService {
         Stream<MeasureValue> unsized = Stream.empty();
 
         if (!stagedRow.getCode().equalsIgnoreCase("snd") && stagedRow.getInverts() > 0) {
-            int seqNo = stagedRow.getSpecies().get().getObsItemType().getObsItemTypeId() == OBS_ITEM_TYPE_DEBRIS ? 1 : 0;
-            unsized = Stream.of(new MeasureValue(seqNo, stagedRow.getInverts()));
+            unsized = Stream.of(new MeasureValue(0, stagedRow.getInverts()));
         }
 
         Stream<MeasureValue> sized = measures.entrySet().stream().map(m -> new MeasureValue(m.getKey(), m.getValue()));

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -162,7 +162,7 @@ public class SurveyIngestionService {
             Measure measure = measureRepository.findByMeasureTypeIdAndSeqNo(measureTypeId, m.getSeqNo()).orElse(null);
             return baseObservationBuilder.measure(measure).measureValue(m.getValue()).build();
         }).collect(Collectors.toList());
-        
+
         return observations;
     }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -149,15 +149,14 @@ public class SurveyIngestionService {
                 if (stagedRow.getSpecies().get().getObsItemType().getObsItemTypeId() == OBS_ITEM_TYPE_NO_SPECIES_FOUND)
                     measureTypeId = MEASURE_TYPE_ABSENCE;
 
-                if (stagedRow.getSpecies().get().getObsItemType().getObsItemTypeId() == OBS_ITEM_TYPE_DEBRIS)
-                    measureTypeId = MEASURE_TYPE_SINGLE_ITEM;
-
             } else if (method == METHOD_M3) {
                 measureTypeId = MEASURE_TYPE_IN_SITU_QUADRAT;
             } else if (method == METHOD_M4) {
                 measureTypeId = MEASURE_TYPE_MACROCYSTIS_BLOCK;
             } else if (method == METHOD_M5) {
                 measureTypeId = MEASURE_TYPE_LIMPET_QUADRAT;
+            } else if (method == METHOD_M12) {
+                measureTypeId = MEASURE_TYPE_SINGLE_ITEM;
             }
 
             Measure measure = measureRepository.findByMeasureTypeIdAndSeqNo(measureTypeId, m.getSeqNo()).orElse(null);

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -264,7 +264,7 @@ public class SurveyIngestionServiceTest {
                                  .measureName("Item")
                                  .measureType(MeasureType.builder().measureTypeId(MEASURE_TYPE_SINGLE_ITEM).build())
                                  .build();
-        when(measureRepository.findByMeasureTypeIdAndSeqNo(MEASURE_TYPE_SINGLE_ITEM, 1)).then(m -> Optional.of(item));
+        when(measureRepository.findByMeasureTypeIdAndSeqNo(MEASURE_TYPE_SINGLE_ITEM, 0)).then(m -> Optional.of(item));
         SurveyMethod surveyMethod7 = SurveyMethod.builder().survey(Survey.builder().surveyId(7).build())
                 .method(Method.builder().methodId(12).methodName("").isActive(true).build()).blockNum(1).build();
         List<Observation> observations7 = surveyIngestionService.getObservations(surveyMethod7,

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -200,7 +200,7 @@ public class SurveyIngestionServiceTest {
                 .method(Method.builder().methodId(1).methodName("").isActive(true).build()).blockNum(1).build();
         List<Observation> observations5 = surveyIngestionService.getObservations(surveyMethod4,
                 rowBuilder.inverts(10).measureJson(Collections.emptyMap()).isInvertSizing(Optional.empty()).method(1).species(
-                        ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(1).build()).build())
+                        Optional.of(ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(1).build()).build()))
                           .build(),
                 false);
         // Should return one observation of 10 unsized species  

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -61,6 +61,7 @@ public class SurveyIngestionServiceTest {
                 .site(Site.builder().siteCode("A SITE").isActive(false).build()).depth(1).surveyNum(Optional.of(2))
                 .direction(Directions.N).vis(Optional.of(15)).date(LocalDate.of(2003, 03, 03))
                 .time(Optional.of(LocalTime.of(12, 34, 56))).pqs(diver).isInvertSizing(Optional.of(true)).code("AAA")
+                .inverts(0)
                 .measureJson(ImmutableMap.<Integer, Integer>builder().put(1, 4).put(3, 7).build()).ref(ref);
     }
 

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -266,9 +266,9 @@ public class SurveyIngestionServiceTest {
                                  .build();
         when(measureRepository.findByMeasureTypeIdAndSeqNo(MEASURE_TYPE_SINGLE_ITEM, 1)).then(m -> Optional.of(item));
         SurveyMethod surveyMethod7 = SurveyMethod.builder().survey(Survey.builder().surveyId(7).build())
-                .method(Method.builder().methodId(2).methodName("").isActive(true).build()).blockNum(1).build();
+                .method(Method.builder().methodId(12).methodName("").isActive(true).build()).blockNum(1).build();
         List<Observation> observations7 = surveyIngestionService.getObservations(surveyMethod7,
-                rowBuilder.inverts(10).measureJson(Collections.emptyMap()).isInvertSizing(Optional.empty()).method(1).species(
+                rowBuilder.inverts(10).measureJson(Collections.emptyMap()).isInvertSizing(Optional.empty()).method(12).species(
                         Optional.of(ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(OBS_ITEM_TYPE_DEBRIS).build()).build()))
                           .build(),
                 false);

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -191,7 +191,7 @@ public class SurveyIngestionServiceTest {
         // M4 should be mapped to measure_type_id = 3 - Macrocystis Block
         assertEquals(3, observations4.get(0).getMeasure().getMeasureType().getMeasureTypeId());
     }
-    
+
     @Test
     void getObservationsM5() {
         when(measureRepository.findByMeasureTypeIdAndSeqNo(7, 1)).then(m -> Optional.of(Measure.builder()

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -237,7 +237,7 @@ public class SurveyIngestionServiceTest {
         assertEquals("1.5cm", observations.get(1).getMeasure().getMeasureName());
         assertEquals(7, observations.get(1).getMeasureValue());
     }
-    
+
     @Test
     void getInvertsObservationM1() {
         Measure unsized = Measure.builder()

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -22,6 +22,8 @@ import java.util.Optional;
 import java.util.stream.IntStream;
 
 import static au.org.aodn.nrmn.restapi.service.SurveyIngestionService.MEASURE_TYPE_FISH_SIZE_CLASS;
+import static au.org.aodn.nrmn.restapi.service.SurveyIngestionService.MEASURE_TYPE_SINGLE_ITEM;
+import static au.org.aodn.nrmn.restapi.service.SurveyIngestionService.OBS_ITEM_TYPE_DEBRIS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
@@ -191,26 +193,6 @@ public class SurveyIngestionServiceTest {
     }
     
     @Test
-    void getInvertsObservation() {
-        Measure unsized = Measure.builder()
-                                 .measureName("Unsized")
-                                 .measureType(MeasureType.builder().measureTypeId(MEASURE_TYPE_FISH_SIZE_CLASS).build())
-                                .build();
-        when(measureRepository.findByMeasureTypeIdAndSeqNo(MEASURE_TYPE_FISH_SIZE_CLASS, 0)).then(m -> Optional.of(unsized));
-        SurveyMethod surveyMethod4 = SurveyMethod.builder().survey(Survey.builder().surveyId(5).build())
-                .method(Method.builder().methodId(1).methodName("").isActive(true).build()).blockNum(1).build();
-        List<Observation> observations5 = surveyIngestionService.getObservations(surveyMethod4,
-                rowBuilder.inverts(10).measureJson(Collections.emptyMap()).isInvertSizing(Optional.empty()).method(1).species(
-                        Optional.of(ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(1).build()).build()))
-                          .build(),
-                false);
-        // Should return one observation of 10 unsized species  
-        assertEquals(1, observations5.size());
-        assertEquals("Unsized", observations5.get(0).getMeasure().getMeasureName());
-        assertEquals(10, observations5.get(0).getMeasureValue());
-    }
-
-    @Test
     void getObservationsM5() {
         when(measureRepository.findByMeasureTypeIdAndSeqNo(7, 1)).then(m -> Optional.of(Measure.builder()
                 .measureName("2.5cm").measureType(MeasureType.builder().measureTypeId(7).build()).build()));
@@ -256,6 +238,46 @@ public class SurveyIngestionServiceTest {
         assertEquals(7, observations.get(1).getMeasureValue());
     }
     
+    @Test
+    void getInvertsObservationM1() {
+        Measure unsized = Measure.builder()
+                                 .measureName("Unsized")
+                                 .measureType(MeasureType.builder().measureTypeId(MEASURE_TYPE_FISH_SIZE_CLASS).build())
+                                 .build();
+        when(measureRepository.findByMeasureTypeIdAndSeqNo(MEASURE_TYPE_FISH_SIZE_CLASS, 0)).then(m -> Optional.of(unsized));
+        SurveyMethod surveyMethod6 = SurveyMethod.builder().survey(Survey.builder().surveyId(6).build())
+                .method(Method.builder().methodId(1).methodName("").isActive(true).build()).blockNum(1).build();
+        List<Observation> observations6 = surveyIngestionService.getObservations(surveyMethod6,
+                rowBuilder.inverts(10).measureJson(Collections.emptyMap()).isInvertSizing(Optional.empty()).method(1).species(
+                        Optional.of(ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(1).build()).build()))
+                          .build(),
+                false);
+        // Should return one observation of 10 unsized species
+        assertEquals(1, observations6.size());
+        assertEquals("Unsized", observations6.get(0).getMeasure().getMeasureName());
+        assertEquals(10, observations6.get(0).getMeasureValue());
+    }
+
+    @Test
+    void getInvertsObservationDebris() {
+        Measure item = Measure.builder()
+                                 .measureName("Item")
+                                 .measureType(MeasureType.builder().measureTypeId(MEASURE_TYPE_SINGLE_ITEM).build())
+                                 .build();
+        when(measureRepository.findByMeasureTypeIdAndSeqNo(MEASURE_TYPE_SINGLE_ITEM, 1)).then(m -> Optional.of(item));
+        SurveyMethod surveyMethod7 = SurveyMethod.builder().survey(Survey.builder().surveyId(7).build())
+                .method(Method.builder().methodId(2).methodName("").isActive(true).build()).blockNum(1).build();
+        List<Observation> observations7 = surveyIngestionService.getObservations(surveyMethod7,
+                rowBuilder.inverts(10).measureJson(Collections.emptyMap()).isInvertSizing(Optional.empty()).method(1).species(
+                        Optional.of(ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(OBS_ITEM_TYPE_DEBRIS).build()).build()))
+                          .build(),
+                false);
+        // Should return one observation of 10 items
+        assertEquals(1, observations7.size());
+        assertEquals("Item", observations7.get(0).getMeasure().getMeasureName());
+        assertEquals(10, observations7.get(0).getMeasureValue());
+    }
+
     @Test
     void ingestSurveyNotDone() {
         when(surveyRepository.save(any())).then(s -> s.getArgument(0));


### PR DESCRIPTION
The inverts total should be included as an unsized  fish size or invert size measure for method 1 and 2 dependent on extended size/use invert sizing flags as per other measures for these methods or as a single item count for debris.  It doesn't apply for other methods/types of items.