### PR TITLE
aodn/backlog#3107 - don't store inverts in measures as well as inverts column

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyContentsHandler.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyContentsHandler.java
@@ -161,8 +161,6 @@ public class SurveyContentsHandler implements SheetContentsHandler {
                 break;
             case "Inverts":
                 currentRow.setInverts(formattedValue);
-                if (formattedValue.length() > 0)
-                    measureJson.put(0, formattedValue);
                 break;
             default:
                 if (formattedValue.length() > 0 && requiredHeaders.contains(columnValue)

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SpreadSheetServiceIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SpreadSheetServiceIT.java
@@ -144,7 +144,7 @@ public class SpreadSheetServiceIT {
                 assertEquals(obs1.getLongitude(), "148.339749");
 
                 // Test Map filling
-                assertEquals(obs1.getMeasureJson().size(), 5);
+                assertEquals(obs1.getMeasureJson().size(), 4);
                 assertEquals(obs1.getMeasureJson().get(21), "4");
 
                 // Test Macro


### PR DESCRIPTION
Its not maintained or displayed in the front end.  Just use the inverts column which is.