### PR TITLE
Include rowId in global error messages

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/base/BaseGlobalFormattedValidator.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/base/BaseGlobalFormattedValidator.java
@@ -19,17 +19,17 @@ public abstract class BaseGlobalFormattedValidator {
 
     abstract public Validated<StagedRowError, String> valid(StagedJob job, List<StagedRowFormatted> rows );
 
-    protected Validated<StagedRowError, String> invalid(Long id, String message, ValidationLevel level) {
+    protected Validated<StagedRowError, String> invalid(Long id, String message, ValidationLevel level, StagedRowFormatted targetRow) {
         return Validated.invalid(
                 new StagedRowError(
                         new ErrorID(
-                                null,
+                                targetRow != null ? targetRow.getRef().getId() : null,
                                 id,
                                 message),
                         ValidationCategory.GLOBAL,
                         level,
                         ruleName,
-                        null
+                        targetRow != null ? targetRow.getRef() : null
                 ));
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/global/formatted/DuplicateRowCheck.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/global/formatted/DuplicateRowCheck.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class DuplicateRowCheck extends BaseGlobalFormattedValidator {
+
     public DuplicateRowCheck() {
         super("Duplicates");
     }
@@ -36,10 +37,9 @@ public class DuplicateRowCheck extends BaseGlobalFormattedValidator {
                 .map(duplicateRow ->
                         invalid(
                                 job.getId(),
-                                String.format("Row %s may be a duplicate of row %s.",
-                                        duplicateRow.getRef().getPos(),
-                                        duplicateRow.getRef().getPos() - 1),
-                                ValidationLevel.WARNING)
+                                "Row may be a duplicate of preceding row",
+                                ValidationLevel.WARNING,
+                                duplicateRow)
                 ).reduce(Validated.valid(""), (acc, elem) -> acc.combine(Monoids.stringConcat, elem));
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/global/formatted/DuplicateRowCheck.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/global/formatted/DuplicateRowCheck.java
@@ -37,7 +37,7 @@ public class DuplicateRowCheck extends BaseGlobalFormattedValidator {
                 .map(duplicateRow ->
                         invalid(
                                 job.getId(),
-                                "Row may be a duplicate of preceding row",
+                                "Row may be a duplicate of the preceding row",
                                 ValidationLevel.WARNING,
                                 duplicateRow)
                 ).reduce(Validated.valid(""), (acc, elem) -> acc.combine(Monoids.stringConcat, elem));

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/global/formatted/Method3QuadratsMissing.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/global/formatted/Method3QuadratsMissing.java
@@ -68,7 +68,7 @@ public class Method3QuadratsMissing extends BaseGlobalFormattedValidator {
         }
 
         return transectSumQuadratsMissing.stream().map(keyQuadrats ->
-             invalid(job.getId(),keyQuadrats._1() + ": missing quadrats", ValidationLevel.BLOCKING)
+             invalid(job.getId(),keyQuadrats._1() + ": missing quadrats", ValidationLevel.BLOCKING, null)
         ).reduce(Validated.valid(""),(acc, error) ->acc.combine(Monoids.stringConcat, error));
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/global/formatted/Method3QuadratsSum.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/validators/global/formatted/Method3QuadratsSum.java
@@ -71,7 +71,8 @@ public class Method3QuadratsSum extends BaseGlobalFormattedValidator {
                         invalid(
                                 job.getId(),
                                 "Transect: " + transectQuadrats._1() + " quadrats sum under 50.",
-                                ValidationLevel.BLOCKING)
+                                ValidationLevel.BLOCKING,
+                                null)
                 ).reduce(Validated.valid(""), (acc, elem) -> acc.combine(Monoids.stringConcat, elem));
     }
 }

--- a/ui/src/components/import/DataSheetView.js
+++ b/ui/src/components/import/DataSheetView.js
@@ -155,7 +155,7 @@ const DataSheetView = ({jobId}) => {
       result.data.errorGlobal.reduce((a, e) => {
         const rowData = {row: e.rowId, columnTarget: '', message: e.message, level: e.errorLevel};
         a[e.columnTarget]?.length > 0 ? a[e.columnTarget].push(rowData) : (a[e.columnTarget] = [rowData]);
-        context.globalErrors.push({rowId: e.rowId, type: e.errorLevel});
+        context.globalErrors.push({rowId: e.rowId, type: e.errorLevel, message: e.message});
         return a;
       }, result.data.summaries);
 
@@ -466,12 +466,10 @@ const DataSheetView = ({jobId}) => {
   };
 
   const toolTipValueGetter = (e) => {
-    const error = e.context.errors.find((r) => r.row === e.data.id && e.column.colId.toUpperCase() === r.column.toUpperCase());
-    if (error) {
-      return error.message;
-    } else {
-      return null;
-    }
+    const error =
+      e.context.errors.find((r) => r.row === e.data.id && e.column.colId.toUpperCase() === r.column.toUpperCase()) ||
+      e.context.globalErrors.find((g) => e.data.id === g.rowId);
+    return error?.message;
   };
 
   return (

--- a/ui/src/components/import/DataSheetView.js
+++ b/ui/src/components/import/DataSheetView.js
@@ -7,6 +7,7 @@ import {
   PlaylistAddCheckOutlined as PlaylistAddCheckOutlinedIcon,
   SaveOutlined as SaveOutlinedIcon
 } from '@material-ui/icons/';
+import {red, orange, yellow, grey, lightGreen} from '@material-ui/core/colors';
 import {NavLink} from 'react-router-dom';
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-material.css';
@@ -21,14 +22,14 @@ import {exportRow, importRow, SubmitingestRequested} from './reducers/create-imp
 import LinearProgressWithLabel from '../ui/LinearProgressWithLabel';
 import AlertDialog from '../ui/AlertDialog';
 
-const useStyles = makeStyles((theme) => {
+const useStyles = makeStyles(() => {
   return {
     fishSize: {
-      color: '#c4d79b',
-      borderBottom: '1px solid ' + theme.palette.divider
+      color: red[200],
+      borderBottom: '1px solid '
     },
     invertSize: {
-      color: '#da9694'
+      color: lightGreen[200]
     }
   };
 });
@@ -85,6 +86,7 @@ const context = {
   undoStack: [],
   summaries: [],
   errors: [],
+  globalErrors: [],
   pushUndo: pushUndo,
   popUndo: popUndo,
 
@@ -132,6 +134,7 @@ const DataSheetView = ({jobId}) => {
     gridApi.showLoadingOverlay();
     gridApi.setFilterModel(null);
     context.errors = [];
+    context.globalErrors = [];
     validateJob(jobId, (result) => {
       context.validationResults = result.data;
 
@@ -150,8 +153,9 @@ const DataSheetView = ({jobId}) => {
       }, context.errors);
 
       result.data.errorGlobal.reduce((a, e) => {
-        const rowData = {columnTarget: '', message: e.message, level: e.errorLevel};
+        const rowData = {row: e.rowId, columnTarget: '', message: e.message, level: e.errorLevel};
         a[e.columnTarget]?.length > 0 ? a[e.columnTarget].push(rowData) : (a[e.columnTarget] = [rowData]);
+        context.globalErrors.push({rowId: e.rowId, type: e.errorLevel});
         return a;
       }, result.data.summaries);
 
@@ -423,9 +427,21 @@ const DataSheetView = ({jobId}) => {
   };
 
   const chooseCellStyle = (params) => {
-    if (params.colDef.field === 'row') return {color: 'grey'};
+    // Highlight global validations
+    const global = params.context.globalErrors.find((g) => g.rowId === params.data.id);
+    if (global) {
+      let color = params.colDef.field === 'row' ? grey[500] : grey[900];
+      if (global.type === 'BLOCKING') return {color: color, backgroundColor: red[100]};
+      if (global.type === 'WARNING') return {color: color, backgroundColor: orange[100]};
+    }
+
+    // Grey-out the first  column containing the row number
+    if (params.colDef.field === 'row') return {color: grey[500]};
+
+    // Highlight and search results
     const row = params.context.highlighted[params.rowIndex];
-    if (row && row[params.colDef.field]) return {backgroundColor: '#fff9c4'};
+    if (row && row[params.colDef.field]) return {backgroundColor: yellow[100]};
+
     // HACK: to work around the fact that invert validation returns the column as an invert size
     // and NOT as the row data column name.
     let fieldName = params.colDef.field.toUpperCase();
@@ -435,9 +451,13 @@ const DataSheetView = ({jobId}) => {
         fieldName = invertSizeMap.field;
       }
     }
+
+    // Highlight cell validations
     const error = params.context.errors.find((e) => e.row === params.data.id && e.column.toUpperCase() === fieldName);
-    if (error?.type === 'BLOCKING') return {backgroundColor: '#ffcdd2'};
-    if (error?.type === 'WARNING') return {backgroundColor: '#fff9c4'};
+    if (error) {
+      if (error.type === 'BLOCKING') return {backgroundColor: red[100]};
+      if (error.type === 'WARNING') return {backgroundColor: orange[100]};
+    }
     return null;
   };
 

--- a/ui/src/components/import/panel/ValidationPanel.js
+++ b/ui/src/components/import/panel/ValidationPanel.js
@@ -61,6 +61,7 @@ const ValidationPanel = (props) => {
     if (item.ids) {
       focusCell(props.api, mapColumnTargetToGridColumn(item.columnTarget), item.ids);
     } else if (item.row) {
+      props.api.setFilterModel(null);
       const rowIdx = props.api.gridOptionsWrapper.gridOptions.context.rowData.findIndex((r) => r.id === item.row);
       props.api.ensureIndexVisible(rowIdx, 'middle');
     }

--- a/ui/src/components/import/panel/ValidationPanel.js
+++ b/ui/src/components/import/panel/ValidationPanel.js
@@ -17,7 +17,6 @@ const focusCell = (api, column, ids) => {
       }
     });
   }
-  api.redrawRows();
 };
 
 const ValidationPanel = (props) => {
@@ -58,6 +57,16 @@ const ValidationPanel = (props) => {
   const blocking = errList.filter((e) => e.blocking);
   const warning = errList.filter((e) => !e.blocking);
 
+  const handleItemClick = (item) => {
+    if (item.ids) {
+      focusCell(props.api, mapColumnTargetToGridColumn(item.columnTarget), item.ids);
+    } else if (item.row) {
+      const rowIdx = props.api.gridOptionsWrapper.gridOptions.context.rowData.findIndex((r) => r.id === item.row);
+      props.api.ensureIndexVisible(rowIdx, 'middle');
+    }
+    props.api.redrawRows();
+  };
+
   return (
     <Box m={2} mr={4}>
       <Button onClick={() => props.api.setFilterModel(null)}>Reset</Button>
@@ -72,16 +81,7 @@ const ValidationPanel = (props) => {
           <AccordionDetails>
             <List>
               {err.value.map((item, i) => (
-                <ListItem
-                  key={i}
-                  onClick={() => {
-                    if (item.ids) {
-                      focusCell(props.api, mapColumnTargetToGridColumn(item.columnTarget), item.ids);
-                    }
-                  }}
-                  style={{backgroundColor: '#ffcdd2'}}
-                  button
-                >
+                <ListItem key={i} onClick={() => handleItemClick(item)} style={{backgroundColor: '#ffcdd2'}} button>
                   <ListItemText color="secondary" primary={item.message} />
                 </ListItem>
               ))}
@@ -108,16 +108,7 @@ const ValidationPanel = (props) => {
           <AccordionDetails>
             <List>
               {err.value.map((item, i) => (
-                <ListItem
-                  onClick={() => {
-                    if (item.ids) {
-                      focusCell(props.api, mapColumnTargetToGridColumn(item.columnTarget), item.ids);
-                    }
-                  }}
-                  style={{backgroundColor: '#ffe0b2'}}
-                  key={i}
-                  button
-                >
+                <ListItem onClick={() => handleItemClick(item)} style={{backgroundColor: '#ffe0b2'}} key={i} button>
                   <ListItemText color="secondary" primary={item.message} />
                 </ListItem>
               ))}


### PR DESCRIPTION
Improvement of work in https://github.com/aodn/backlog/issues/3168

@nspool This will make the Duplicate Rows Check include the rowId in the payload. This is the first step in highlighting the duplicated row. It requires front-end changes to match.

Global Error payload:
```json
{
   "errorGlobal":[
      {
         "rowId":1500,
         "jobId":14,
         "message":"Row 99 may be a duplicate of row 98.",
         "errorType":"GLOBAL",
         "errorLevel":"WARNING",
         "columnTarget":"Duplicates"
      }
   ]
}
```