### PR TITLE
Clear supersededBy when no option is selected

### DIFF
--- a/ui/src/components/data-entities/EntityEdit.js
+++ b/ui/src/components/data-entities/EntityEdit.js
@@ -117,7 +117,7 @@ const EntityEdit = ({entity, template, clone}) => {
         ]
       };
     } else if (key === 'supersededBy') {
-      uiSchema[key] = {'ui:field': 'searchInput', exclude: 'observableItemName'};
+      uiSchema[key] = {'ui:field': 'searchInput', exclude: 'observableItemName', clearOnBlur: true};
     } else if (item.format === 'double') {
       uiSchema[key] = {'ui:field': 'double'};
     } else if (item.type === 'boolean') {

--- a/ui/src/components/data-entities/customWidgetFields/SearchInput.js
+++ b/ui/src/components/data-entities/customWidgetFields/SearchInput.js
@@ -18,6 +18,7 @@ const SearchInput = ({schema, name, uiSchema}) => {
       <Typography variant="subtitle2">{schema.title}</Typography>
       <Autocomplete
         options={searchResults?.map((i) => i.species).filter((f) => f !== exclude) ?? []}
+        clearOnBlur={uiSchema.clearOnBlur}
         freeSolo
         defaultValue={value}
         onSelect={(e) => {


### PR DESCRIPTION
Backlog item: https://github.com/aodn/backlog/issues/3130

Clears after blur - The options remain filtered though, I could not find an appropriate hook to reset them.