### PR TITLE
Use primitive values to avoid nulls

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SpeciesWithAttributesCsvRow.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SpeciesWithAttributesCsvRow.java
@@ -20,4 +20,8 @@ public class SpeciesWithAttributesCsvRow {
     private Double l95;
 
     private Long lMax;
+
+    public boolean getPrimitiveInvertSized() {
+        return isInvertSized != null && isInvertSized;
+    }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/TemplateService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/TemplateService.java
@@ -1,42 +1,32 @@
 package au.org.aodn.nrmn.restapi.service;
 
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
-
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.OutputStreamWriter;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
-
+import au.org.aodn.nrmn.restapi.model.db.Diver;
+import au.org.aodn.nrmn.restapi.model.db.Location;
+import au.org.aodn.nrmn.restapi.model.db.Site;
+import au.org.aodn.nrmn.restapi.repository.*;
+import au.org.aodn.nrmn.restapi.repository.projections.LetterCodeMapping;
+import au.org.aodn.nrmn.restapi.repository.projections.ObservableItemRow;
+import au.org.aodn.nrmn.restapi.repository.projections.SpeciesWithAttributesCsvRow;
+import cyclops.companion.Streams;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Example;
 import org.springframework.stereotype.Service;
 
-import au.org.aodn.nrmn.restapi.model.db.Diver;
-import au.org.aodn.nrmn.restapi.model.db.Location;
-import au.org.aodn.nrmn.restapi.model.db.Site;
-import au.org.aodn.nrmn.restapi.repository.DiverRepository;
-import au.org.aodn.nrmn.restapi.repository.LetterCodeRepository;
-import au.org.aodn.nrmn.restapi.repository.ObservableItemRepository;
-import au.org.aodn.nrmn.restapi.repository.ObservationRepository;
-import au.org.aodn.nrmn.restapi.repository.SiteRepository;
-import au.org.aodn.nrmn.restapi.repository.projections.LetterCodeMapping;
-import au.org.aodn.nrmn.restapi.repository.projections.ObservableItemRow;
-import au.org.aodn.nrmn.restapi.repository.projections.SpeciesWithAttributesCsvRow;
-import cyclops.companion.Streams;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
 
 @Service
 public class TemplateService {
@@ -185,7 +175,7 @@ public class TemplateService {
 
     private List<String> getSpeciesAsCsvRecord(SpeciesWithAttributesCsvRow species) {
         return Arrays.asList(species.getLetterCode(), species.getSpeciesName(), species.getCommonName(),
-                species.getIsInvertSized() ? "Yes" : "No", toString(species.getL5()), toString(species.getL95()),
+                species.getPrimitiveInvertSized() ? "Yes" : "No", toString(species.getL5()), toString(species.getL95()),
                 toString(species.getLMax()));
     }
 


### PR DESCRIPTION
Fixes issue with download template data resulting in 500 error