### PR TITLE
Remove any invalid superseded value

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/ObservableItemController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/ObservableItemController.java
@@ -95,17 +95,8 @@ public class ObservableItemController {
         }
 
         if(!StringUtils.isEmpty(item.getSupersededBy()) && observableItemRepository.exactSearch(item.getSupersededBy()).isEmpty()){
-
-            if(item.getObservableItemId() != null){
-                ObservableItem originalItem = observableItemRepository
-                        .findById(item.getObservableItemId()).orElseThrow(ResourceNotFoundException::new);
-                logger.info(String.format("Invalid supersededBy value: \"%s\". Setting to previous value \"%s\".",
-                        originalItem.getSupersededBy(), originalItem.getSupersededBy()));
-                item.setSupersededBy(originalItem.getSupersededBy());
-            } else {
-                logger.info(String.format("Invalid supersededBy value: \"%s\". Setting to null.", item.getSupersededBy()));
-                item.setSupersededBy(null);
-            }
+            logger.info(String.format("Invalid supersededBy value: \"%s\". Setting to null.", item.getSupersededBy()));
+            item.setSupersededBy(null);
 
         }
 


### PR DESCRIPTION
Backlog item: https://github.com/aodn/backlog/issues/3130

This is a more unforgiving method of dealing with invalid/incomplete values.

The previous method would revert the value back to the previous `supersed_by` value if it existed. This method simply sets any invalid values to null.