### PR TITLE
AG Grid License: Persist between refreshes

### DIFF
--- a/ui/src/App.js
+++ b/ui/src/App.js
@@ -5,6 +5,7 @@ import Alert from '@material-ui/lab/Alert';
 import {ThemeProvider, unstable_createMuiStrictModeTheme as createMuiTheme, responsiveFontSizes} from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import {blueGrey, deepPurple} from '@material-ui/core/colors';
+import {LicenseManager} from 'ag-grid-enterprise';
 import TopBar from './components/layout/TopBar';
 import SideMenu from './components/layout/SideMenu';
 import Login from './components/auth/login';
@@ -169,6 +170,8 @@ const App = () => {
   window.setApplicationError = setApplicationError;
 
   const loggedIn = Date.now() < expires;
+
+  LicenseManager.setLicenseKey(JSON.parse(localStorage.getItem('gridLicense')));
 
   let theme = createMuiTheme({
     palette: {

--- a/ui/src/components/auth/auth-reducer.js
+++ b/ui/src/components/auth/auth-reducer.js
@@ -23,6 +23,7 @@ const authSlice = createSlice({
       state.success = true;
       state.loading = false;
       localStorage.setItem('auth', JSON.stringify(state));
+      localStorage.setItem('gridLicense', JSON.stringify(action.payload.gridLicense));
       LicenseManager.setLicenseKey(action.payload.gridLicense);
     },
     loginFailed: (state) => {


### PR DESCRIPTION
Store the AG Grid license in local storage and set on page render. This is to prevent the grid from losing the license if the window is closed and opened again, or the page is refreshed.