### PR TITLE
Changed validate to reference site_ref rather than materialized view

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SiteRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SiteRepository.java
@@ -27,7 +27,7 @@ public interface SiteRepository extends JpaRepository<Site, Integer>, JpaSpecifi
     @QueryHints({@QueryHint(name = HINT_CACHEABLE, value = "true")})
     List<Site> findByCriteria(@Param("code") String siteCode);
 
-    @Query(value = "SELECT site_code FROM {h-schema}ep_site_list WHERE site_code IN :siteCodes", nativeQuery = true)
+    @Query(value = "SELECT siteCode FROM Site WHERE siteCode IN :siteCodes")
     List<String> getAllSiteCodesMatching(Collection<String> siteCodes);
     
     @Query("SELECT s FROM Site s")


### PR DESCRIPTION
Backlog item: https://github.com/aodn/backlog/issues/3323

@nspool is there a reason why we are referencing `ep_site_list` here. I can see that it may be filtered to sites that have locations and meow_ecoregions but I am not sure if that is a requirement for this. Also, I am not sure why this view is materialized considering it takes 1s to generate, unless its being referenced elsewhere and needs an index.