### PR TITLE
Prevent null survey number

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
@@ -78,7 +78,7 @@ public class StagedRowFormattedMapperConfig {
         Converter<String, Integer> toSurveyNum = ctx -> {
             String[] splitDepth = ctx.getSource().split("\\.");
             try {
-                return splitDepth.length > 1 ? Integer.parseInt(splitDepth[1]) : null;
+                return splitDepth.length > 1 ? Integer.parseInt(splitDepth[1]) : 0;
             } catch (NumberFormatException e) {
                 return null;
             }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
@@ -79,6 +79,6 @@ public class StagedRowFormatted {
     }
 
     public String getSurveyGroup() {
-        return getSurvey() != null  && surveyNum != null ? (getSurvey() + "." + surveyNum).toUpperCase() : null;
+        return getSurvey() != null ? (getSurvey() + "." + surveyNum).toUpperCase() : null;
     }
 }


### PR DESCRIPTION
RLS depth may not have a survey number. Fall back to using zero as survey number.