### PR TITLE
Refresh materialized views on ingest

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/MaterializedViewsRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/MaterializedViewsRepository.java
@@ -1,0 +1,104 @@
+package au.org.aodn.nrmn.restapi.repository;
+
+import au.org.aodn.nrmn.restapi.model.db.AphiaRef;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import javax.transaction.Transactional;
+
+@Transactional
+@Tag(name = "materialized views")
+public interface MaterializedViewsRepository extends JpaRepository<AphiaRef, Integer>, JpaSpecificationExecutor<AphiaRef> {
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW CONCURRENTLY nrmn.ep_m1'", nativeQuery = true)
+    Boolean checkEpM1Running();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW CONCURRENTLY nrmn.ep_m1;", nativeQuery = true)
+    void refreshEpM1();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ep_m2_cryptic_fish'", nativeQuery = true)
+    Boolean checkEpM2CrypticFishRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ep_m2_cryptic_fish;", nativeQuery = true)
+    void refreshEpM2CrypticFish();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ep_m2_inverts'", nativeQuery = true)
+    Boolean checkEpM2InvertsRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ep_m2_inverts;", nativeQuery = true)
+    void refreshEpM2Inverts();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ep_observable_items'", nativeQuery = true)
+    Boolean checkEpObservableItemsRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ep_observable_items;", nativeQuery = true)
+    void refreshEpObservableItems();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ep_rarity_abundance'", nativeQuery = true)
+    Boolean checkEpRarityAbundanceRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ep_rarity_abundance;", nativeQuery = true)
+    void refreshEpRarityAbundance();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ep_rarity_extents'", nativeQuery = true)
+    Boolean checkEpRarityExtentsRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ep_rarity_extents;", nativeQuery = true)
+    void refreshEpRarityExtents();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW CONCURRENTLY nrmn.ep_rarity_frequency'", nativeQuery = true)
+    Boolean checkEpRarityFrequencyRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW CONCURRENTLY nrmn.ep_rarity_frequency;", nativeQuery = true)
+    void refreshEpRarityFrequency();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ep_rarity_range'", nativeQuery = true)
+    Boolean checkEpRarityRangeRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ep_rarity_range;", nativeQuery = true)
+    void refreshEpRarityRange();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ep_site_list'", nativeQuery = true)
+    Boolean checkEpSiteListRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ep_site_list;", nativeQuery = true)
+    void refreshEpSiteList();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ep_survey_list'", nativeQuery = true)
+    Boolean checkEpSurveyListRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ep_survey_list;", nativeQuery = true)
+    void refreshEpSurveyList();
+
+
+    @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW nrmn.ui_species_attributes'", nativeQuery = true)
+    Boolean checkUiSpeciesAttributesRunning();
+
+    @Modifying
+    @Query(value = "REFRESH MATERIALIZED VIEW nrmn.ui_species_attributes;", nativeQuery = true)
+    void refreshUiSpeciesAttributes();
+
+
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/MaterializedViewsRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/MaterializedViewsRepository.java
@@ -1,9 +1,8 @@
 package au.org.aodn.nrmn.restapi.repository;
 
-import au.org.aodn.nrmn.restapi.model.db.AphiaRef;
+import au.org.aodn.nrmn.restapi.model.db.ObservableItem;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
@@ -11,7 +10,7 @@ import javax.transaction.Transactional;
 
 @Transactional
 @Tag(name = "materialized views")
-public interface MaterializedViewsRepository extends JpaRepository<AphiaRef, Integer>, JpaSpecificationExecutor<AphiaRef> {
+public interface MaterializedViewsRepository extends JpaRepository<ObservableItem, Integer> {
 
     @Query(value = "SELECT COUNT(*) > 0 FROM pg_stat_activity WHERE query = 'REFRESH MATERIALIZED VIEW CONCURRENTLY nrmn.ep_m1'", nativeQuery = true)
     Boolean checkEpM1Running();

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/MaterializedViewService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/MaterializedViewService.java
@@ -1,0 +1,116 @@
+package au.org.aodn.nrmn.restapi.service;
+
+import au.org.aodn.nrmn.restapi.repository.MaterializedViewsRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.stereotype.Component;
+
+@Component
+@EnableAsync
+public class MaterializedViewService {
+
+    private static final Logger logger = LoggerFactory.getLogger(MaterializedViewService.class);
+
+    @Autowired
+    MaterializedViewsRepository materializedViewsRepository;
+
+    @Async
+    public void refreshAllMaterializedViews() {
+
+        logger.info("Starting materialization of endpoint views");
+
+        if(materializedViewsRepository.checkUiSpeciesAttributesRunning()) {
+            logger.info("ui_species_attributes is already being refreshed");
+        } else {
+            logger.info("refreshing ui_species_attributes");
+            materializedViewsRepository.refreshUiSpeciesAttributes();
+            logger.info("ui_species_attributes refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpM2CrypticFishRunning()) {
+            logger.info("ep_m2_cryptic_fish is already being refreshed");
+        } else {
+            logger.info("refreshing ep_m2_cryptic_fish");
+            materializedViewsRepository.refreshEpM2CrypticFish();
+            logger.info("ep_m2_cryptic_fish refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpM2InvertsRunning()) {
+            logger.info("ep_m2_inverts is already being refreshed");
+        } else {
+            logger.info("refreshing ep_m2_inverts");
+            materializedViewsRepository.refreshEpM2Inverts();
+            logger.info("ep_m2_inverts refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpObservableItemsRunning()) {
+            logger.info("ep_observable_items is already being refreshed");
+        } else {
+            logger.info("refreshing ep_observable_items");
+            materializedViewsRepository.refreshEpObservableItems();
+            logger.info("ep_observable_items refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpRarityAbundanceRunning()) {
+            logger.info("ep_rarity_abundance is already being refreshed");
+        } else {
+            logger.info("refreshing ep_rarity_abundance");
+            materializedViewsRepository.refreshEpRarityAbundance();
+            logger.info("ep_rarity_abundance refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpRarityExtentsRunning()) {
+            logger.info("ep_rarity_extents is already being refreshed");
+        } else {
+            logger.info("refreshing ep_rarity_extents");
+            materializedViewsRepository.refreshEpRarityExtents();
+            logger.info("ep_rarity_extents refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpRarityRangeRunning()) {
+            logger.info("ep_rarity_range is already being refreshed");
+        } else {
+            logger.info("refreshing ep_rarity_range");
+            materializedViewsRepository.refreshEpRarityRange();
+            logger.info("ep_rarity_range refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpSiteListRunning()) {
+            logger.info("ep_site_list is already being refreshed");
+        } else {
+            logger.info("refreshing ep_site_list");
+            materializedViewsRepository.refreshEpSiteList();
+            logger.info("ep_site_list refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpSurveyListRunning()) {
+            logger.info("ep_survey_list is already being refreshed");
+        } else {
+            logger.info("refreshing ep_survey_list");
+            materializedViewsRepository.refreshEpSurveyList();
+            logger.info("ep_survey_list refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpM1Running()) {
+            logger.info("ep_m1 is already being refreshed");
+        } else {
+            logger.info("refreshing ep_m1");
+            materializedViewsRepository.refreshEpM1();
+            logger.info("ep_m1 refresh complete");
+        }
+
+        if(materializedViewsRepository.checkEpRarityFrequencyRunning()) {
+            logger.info("ep_rarity_frequency is already being refreshed");
+        } else {
+            logger.info("refreshing ep_rarity_frequency");
+            materializedViewsRepository.refreshEpRarityFrequency();
+            logger.info("ep_rarity_frequency refresh complete");
+        }
+
+        logger.info("Re-materialization complete");
+
+    }
+}

--- a/api/src/main/resources/sql/application.sql
+++ b/api/src/main/resources/sql/application.sql
@@ -370,3 +370,6 @@ CREATE SEQUENCE IF NOT EXISTS nrmn.staged_job_log_id_seq;
 CREATE SEQUENCE IF NOT EXISTS nrmn.user_id_seq;
 
 ALTER SEQUENCE nrmn.staged_row_id_seq INCREMENT BY 100;
+
+CREATE UNIQUE INDEX idx_unique_ep_rarity_frequency_taxon ON nrmn.ep_rarity_frequency(taxon);
+CREATE UNIQUE INDEX idx_unique_ep_m1 ON nrmn.ep_m1(survey_id, recorded_species_name, size_class, block, "method", diver);


### PR DESCRIPTION
Backlog item: https://github.com/aodn/backlog/issues/3234

When 5 tasks are running concurrently the following log output is produced. I have reformatted it to show how the concurrent tasks handle the views:

table_name | task1 | task2 | task3 | task4 | task5
-- | -- | -- | -- | -- | --
ui_species_attributes | refreshing ui_species_attributes | ui_species_attributes is already being refreshed | ui_species_attributes is already being refreshed | ui_species_attributes is already being refreshed | ui_species_attributes is already being refreshed
ep_m2_cryptic_fish | ep_m2_cryptic_fish is already being refreshed | refreshing ep_m2_cryptic_fish | ep_m2_cryptic_fish is already being refreshed | ep_m2_cryptic_fish is already being refreshed | ep_m2_cryptic_fish is already being refreshed
ep_m2_inverts | ep_m2_inverts is already being refreshed | ep_m2_inverts is already being refreshed | refreshing ep_m2_inverts | ep_m2_inverts is already being refreshed | ep_m2_inverts is already being refreshed
ep_observable_items | ep_observable_items is already being refreshed | ep_observable_items is already being refreshed | ep_observable_items is already being refreshed | refreshing ep_observable_items | ep_observable_items is already being refreshed
ep_rarity_abundance | ep_rarity_abundance is already being refreshed | ep_rarity_abundance is already being refreshed | refreshing ep_rarity_abundance | refreshing ep_rarity_abundance | refreshing ep_rarity_abundance
ep_rarity_extents | refreshing ep_rarity_extents | ep_rarity_extents is already being refreshed | ep_rarity_extents is already being refreshed | refreshing ep_rarity_extents | refreshing ep_rarity_extents
ep_rarity_range | ep_rarity_range is already being refreshed | refreshing ep_rarity_range | refreshing ep_rarity_range | refreshing ep_rarity_range | ep_rarity_range is already being refreshed
ep_site_list | refreshing ep_site_list | ep_site_list is already being refreshed | ep_site_list is already being refreshed | refreshing ep_site_list | refreshing ep_site_list
ep_survey_list | ep_survey_list is already being refreshed | refreshing ep_survey_list | refreshing ep_survey_list | refreshing ep_survey_list | ep_survey_list is already being refreshed
ep_m1 | refreshing ep_m1 | ep_m1 is already being refreshed | ep_m1 is already being refreshed | refreshing ep_m1 | refreshing ep_m1
ep_rarity_frequency | refreshing ep_rarity_frequency | refreshing ep_rarity_frequency | ep_rarity_frequency is already being refreshed | refreshing ep_rarity_frequency | refreshing ep_rarity_frequency

