### PR TITLE
Site add: allow old site codes

### DIFF
--- a/ui/src/components/data-entities/EntityEdit.js
+++ b/ui/src/components/data-entities/EntityEdit.js
@@ -45,7 +45,6 @@ const EntityEdit = ({entity, template, clone}) => {
       dispatch(updateEntityRequested(data));
     } else {
       delete e.formData.siteAttribute;
-      delete e.formData.oldSiteCodes;
       const data = {path: entity.endpoint, data: e.formData};
       dispatch(createEntityRequested(data));
     }

--- a/ui/src/components/templates/SiteAddTemplate.js
+++ b/ui/src/components/templates/SiteAddTemplate.js
@@ -42,6 +42,9 @@ const SiteAddTemplate = (props) => {
         <Grid item xs={6}>
           {el['protectionStatus']}
         </Grid>
+        <Grid item xs={12}>
+          {el['oldSiteCodes']}
+        </Grid>
       </Grid>
     </Box>
   );


### PR DESCRIPTION
Any validation errors will remove any added site codes from the form. There doesn't appear to be a way around this without reimplementing the generic UI "array of fields" function used for site codes.