### PR TITLE
Delete row that is displaying the context menu

### DIFF
--- a/ui/src/components/import/DataSheetView.js
+++ b/ui/src/components/import/DataSheetView.js
@@ -483,7 +483,14 @@ const DataSheetView = ({jobId, onIngest}) => {
     const startIdx = Math.min(cells.startRow.rowIndex, cells.endRow.rowIndex);
     const endIdx = Math.max(cells.startRow.rowIndex, cells.endRow.rowIndex);
     const delta = [];
-    if (startIdx === endIdx) {
+
+    if (startIdx === endIdx && startIdx === e.node.rowIndex) {
+      e.api.getSelectedRows().forEach(() => {
+        const data = e.node.data;
+        delta.push({...data});
+        rowData.splice(rowData.indexOf(data), 1);
+      });
+    } else if (startIdx === endIdx) {
       e.api.getSelectedRows().forEach((row) => {
         const data = rowData.find((d) => d.id === row.id);
         delta.push({...data});


### PR DESCRIPTION
Backlog item: https://github.com/aodn/backlog/issues/3356

I think that given this is carving out a new exception on top of existing criteria this is safer than we originally thought