### PR TITLE
Go live fixes

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedRow.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedRow.java
@@ -149,4 +149,13 @@ public class StagedRow implements Serializable {
         return Integer.toString(rowContents.hashCode());
     }
 
+    public String getSurvey() {
+        String depthPart = depth.split("\\.")[0];
+        return (siteCode.trim() + "/" + date.trim() + "/" + depthPart).toUpperCase();
+    }
+
+    public String getSurveyGroup() {
+        return (siteCode.trim() + "/" + date.trim() + "/" + depth.trim()).toUpperCase();
+    }
+
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyContentsHandler.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyContentsHandler.java
@@ -69,7 +69,7 @@ public class SurveyContentsHandler implements SheetContentsHandler {
             if (errors.size() > 0)
                 error = String.join(". ", errors);
         } else {
-            if (rowHasId) {
+            if (rowHasId && rowNum > 1) {
                 currentRow.setMeasureJson(new HashMap<Integer, String>(measureJson));
                 this.stagedRows.add(currentRow);
             } else {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyContentsHandler.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyContentsHandler.java
@@ -108,7 +108,8 @@ public class SurveyContentsHandler implements SheetContentsHandler {
     private void setValue(String columnHeader, String formattedValue) {
         switch (columnHeader) {
             case "ID":
-                rowHasId = formattedValue.length() > 0;
+                // For now stage all rows regardless of ID
+                rowHasId = true; // formattedValue.length() > 0;
                 break;
             case "Buddy":
                 currentRow.setBuddy(formattedValue);

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
@@ -77,12 +77,12 @@ public class StagedRowFormatted {
                 && Objects.equals(method, that.method)
                 && Objects.equals(species, that.species);
     }
-    
+
     public String getSurvey() {
-        return site != null && site.getSiteCode() != null && date != null && depth != null ? (site.getSiteCode() + "/" + date + "/" + depth).toUpperCase() : null;
+        return ref.getSurvey();
     }
 
     public String getSurveyGroup() {
-        return getSurvey() != null ? (getSurvey() + "." + surveyNum).toUpperCase() : null;
+        return ref.getSurveyGroup();
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -624,11 +624,11 @@ public class ValidationProcess {
         Collection<StagedRowFormatted> validRows = formatRowsWithSpecies(rows, species);
 
         if (validRows != null) {
-            Object[] distinctSites = validRows.stream().map(r ->r.getSite() != null ? r.getSite().getSiteCode() : null).filter(s -> s!= null).distinct().toArray();
+            Object[] distinctSites = validRows.stream().map(r ->r.getRef().getSiteCode().trim()).filter(s -> s!= null).distinct().toArray();
             response.setRowCount(validRows.size());
             response.setSiteCount(distinctSites.length);
-            response.setDiverCount(validRows.stream().map(r -> r.getDiver()).distinct().count());
-            response.setObsItemCount(validRows.stream().map(r -> r.getSpecies()).filter(o -> o.isPresent()).distinct().count());
+            response.setDiverCount(validRows.stream().map(r -> r.getRef().getDiver().trim()).distinct().count());
+            response.setObsItemCount(validRows.stream().map(r -> r.getRef().getSpecies().trim()).distinct().count());
 
             sheetErrors.addAll(checkData(programName, job.getIsExtendedSize(), validRows));
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -465,21 +465,22 @@ public class ValidationProcess {
             return new ValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING, "Method 0 must have block 0, 1 or 2",
                         method0Rows.stream().map(r -> r.getId()).collect(Collectors.toList()), Arrays.asList("block"));
 
-        // VALIDATE: Both M1 and M2 present except if ATRC and has at least one method of 3,4,5,7
-        List<Integer> methods =  new ArrayList<Integer>(Arrays.asList(1,2));
-        methods.removeAll(surveyByMethod.keySet());
-        if(methods.size() > 0 && !(programName.equalsIgnoreCase("ATRC") && surveyRows.stream().filter(r -> Arrays.asList(3, 4, 5, 7).contains(r.getMethod())).count() > 0)) {
-            List<String> missingMethods = methods.stream().map(m -> m.toString()).collect(Collectors.toList());
-            return new ValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING, "Survey incomplete: missing " + String.join(", ", missingMethods), 
+        // VALIDATE: Both M1, M2 present and if ATRC has M3 and at least one method of 3,4,5,7
+        List<Integer> requiredMethods = programName.equalsIgnoreCase("ATRC") ? Arrays.asList(1,2,3) : Arrays.asList(1,2);
+        List<Integer> missingMethods =  new ArrayList<Integer>(requiredMethods);
+        missingMethods.removeAll(surveyByMethod.keySet());
+        if(missingMethods.size() > 0 && !(programName.equalsIgnoreCase("ATRC") && surveyRows.stream().filter(r -> Arrays.asList(3, 4, 5, 7).contains(r.getMethod())).count() > 0)) {
+            List<String> missingMethodsList = missingMethods.stream().map(m -> m.toString()).collect(Collectors.toList());
+            return new ValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING, "Survey incomplete: missing " + String.join(", ", missingMethodsList), 
                                         surveyRows.stream().map(r -> r.getId()).collect(Collectors.toList()), Arrays.asList("method"));
         }
 
-        // VALIDATE: Each method has block 1,2 (RLS) or block 1 (ATRC)
-        for (Integer method : Arrays.asList(1,2)) {
+        // VALIDATE: Each method has block 1,2 (RLS) or block 1 (ATRC) except ATRC M3 which should have block 0
+        for (Integer method : Arrays.asList(1,2,3)) {
             List<StagedRowFormatted> methodRows = surveyByMethod.get(method);
             if(methodRows == null) continue;
 
-            List<Integer> blocksRequired = programName.equalsIgnoreCase("RLS") ? new ArrayList<Integer>(Arrays.asList(1,2)) : new ArrayList<Integer>(Arrays.asList(1));
+            List<Integer> blocksRequired = programName.equalsIgnoreCase("RLS") ? new ArrayList<Integer>(Arrays.asList(1,2)) : new ArrayList<Integer>(method == 3 ? Arrays.asList(0) : Arrays.asList(1));
 
             List<Integer> hasBlocks = methodRows.stream().map(r -> r.getBlock()).distinct().filter(b -> b != 0).collect(Collectors.toList());
             List<Integer> missingBlocks = blocksRequired.stream().filter(b -> !hasBlocks.contains(b)).collect(Collectors.toList());

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SpreadSheetServiceIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SpreadSheetServiceIT.java
@@ -103,7 +103,7 @@ public class SpreadSheetServiceIT {
         ParsedSheet parsedSheet = sheetService.stageXlsxFile(new MockMultipartFile("sheets/correctShortHeader3.xlsx", file3.getInputStream()), false);
 
         val stageSurveys = parsedSheet.getStagedRows();
-        assertEquals(stageSurveys.size(), 2);
+        assertEquals(23, stageSurveys.size());
         val obs1 = stageSurveys.get(0);
 
         // Test Double

--- a/ui/src/components/import/panel/ValidationSummary.js
+++ b/ui/src/components/import/panel/ValidationSummary.js
@@ -82,7 +82,7 @@ const ValidationSummary = (props) => {
                           Check Column{d.columnNames.length > 1 ? 's' : ''} {d.columnNames.join(', ')}
                         </b>
                       ) : (
-                        <b>Region contains invalid values</b>
+                        <b>Missing value</b>
                       )}
                     </Typography>
                   </div>


### PR DESCRIPTION
Remove ID check when staging surveys
Generate summaries based on staged input data. Previously it was only generating summaries from validated rows.
Implement additional ATRC M3 rules:
 - ATRC Surveys must contain at least one row of M3
 - Must also have at least one row with M3 and block 0