### PR TITLE
Fix survey method assignment on ingest

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -198,7 +198,7 @@ public class SurveyIngestionService {
             if (r.getSpecies().isPresent() && r.getSpecies().get().getObsItemType().getObsItemTypeId() == OBS_ITEM_TYPE_DEBRIS)
                 r.setMethod(METHOD_M12);
             return r;
-        }).filter(r -> r.getSurveyWithMethod() != null).collect(Collectors.groupingBy(StagedRowFormatted::getSurveyWithMethod));
+        }).filter(r -> r.getMethodBlock() != null).collect(Collectors.groupingBy(StagedRowFormatted::getMethodBlock));
     }
 
     @Transactional
@@ -210,8 +210,7 @@ public class SurveyIngestionService {
             Survey survey = getSurvey(surveyRows.get(0));
             groupRowsBySurveyMethod(surveyRows).values().forEach(surveyMethodRows -> {
                 SurveyMethod surveyMethod = getSurveyMethod(survey, surveyMethodRows.get(0));
-                surveyMethodRows.forEach(row -> observationRepository
-                        .saveAll(getObservations(surveyMethod, row, job.getIsExtendedSize())));
+                surveyMethodRows.forEach(row -> observationRepository.saveAll(getObservations(surveyMethod, row, job.getIsExtendedSize())));
             });
             return survey.getSurveyId();
         }).collect(Collectors.toList());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -193,12 +193,8 @@ public class SurveyIngestionService {
         return observations;
     }
 
-    public Map<String, List<StagedRowFormatted>> groupRowsBySurveyMethod(List<StagedRowFormatted> surveyRows) {
-        return surveyRows.stream().map(r -> {
-            if (r.getSpecies().isPresent() && r.getSpecies().get().getObsItemType().getObsItemTypeId() == OBS_ITEM_TYPE_DEBRIS)
-                r.setMethod(METHOD_M12);
-            return r;
-        }).filter(r -> r.getMethodBlock() != null).collect(Collectors.groupingBy(StagedRowFormatted::getMethodBlock));
+    public Map<String, List<StagedRowFormatted>> groupRowsByMethodBlock(List<StagedRowFormatted> surveyRows) {
+        return surveyRows.stream().filter(r -> r.getMethodBlock() != null).collect(Collectors.groupingBy(StagedRowFormatted::getMethodBlock));
     }
 
     @Transactional
@@ -208,9 +204,9 @@ public class SurveyIngestionService {
 
         List<Integer> surveyIds = rowsGroupedBySurvey.values().stream().map(surveyRows -> {
             Survey survey = getSurvey(surveyRows.get(0));
-            groupRowsBySurveyMethod(surveyRows).values().forEach(surveyMethodRows -> {
-                SurveyMethod surveyMethod = getSurveyMethod(survey, surveyMethodRows.get(0));
-                surveyMethodRows.forEach(row -> observationRepository.saveAll(getObservations(surveyMethod, row, job.getIsExtendedSize())));
+            groupRowsByMethodBlock(surveyRows).values().forEach(methodBlockRows -> {
+                SurveyMethod surveyMethod = getSurveyMethod(survey, methodBlockRows.get(0));
+                methodBlockRows.forEach(row -> observationRepository.saveAll(getObservations(surveyMethod, row, job.getIsExtendedSize())));
             });
             return survey.getSurveyId();
         }).collect(Collectors.toList());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
@@ -87,8 +87,8 @@ public class StagedRowFormatted {
                 && Objects.equals(species, that.species);
     }
 
-    public String getSurveyWithMethod() {
-        return method != null ? ref.getSurvey() + '-' + method : null;
+    public String getMethodBlock() {
+        return method.toString() + '-' + block.toString();
     }
 
     public String getSurvey() {

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -335,16 +335,4 @@ public class SurveyIngestionServiceTest {
         assertEquals(true, surveyMethod.getSurveyNotDone());
 
     }
-
-    @Test
-    void getObservationsDebrisSavedAsM12() {
-
-        ObservableItem debrisItem = ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(5).build()).build();
-        StagedRowFormatted row = rowBuilder.isInvertSizing(true).species(Optional.of(debrisItem)).build();
-
-        StagedRowFormatted groupedRow = surveyIngestionService.groupRowsBySurveyMethod(Arrays.asList(row)).values().iterator().next().get(0);
-
-        // Debris are entered as M2 but stored as M12
-        assertEquals(12, groupedRow.getMethod());
-    }
 }


### PR DESCRIPTION
Should be by method / block combo, not surveynum / method.

Also remove the M12 override for debris observations.

Stack containing fix: http://nrmn-aodnstack-nspool.dev.aodn.org.au/home