### PR TITLE
Invert, Debris Zero and duplicate row validation improvements

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/enums/ValidationLevel.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/enums/ValidationLevel.java
@@ -1,5 +1,5 @@
 package au.org.aodn.nrmn.restapi.model.db.enums;
 
 public enum ValidationLevel {
-    WARNING, BLOCKING
+    WARNING, BLOCKING, DUPLICATE
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -126,7 +126,7 @@ public class SurveyIngestionService {
     }
 
     public SurveyMethod getSurveyMethod(Survey survey, StagedRowFormatted stagedRow) {
-        boolean surveyNotDone = stagedRow.getRef().getSpecies().toLowerCase().equals("Survey Not Done");
+        boolean surveyNotDone = stagedRow.getRef().getSpecies().equalsIgnoreCase("Survey Not Done");
         Method method = entityManager.getReference(Method.class, stagedRow.getMethod());
         SurveyMethod surveyMethod = SurveyMethod.builder().survey(survey).method(method).blockNum(stagedRow.getBlock())
                 .surveyNotDone(surveyNotDone).build();

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -126,7 +126,7 @@ public class SurveyIngestionService {
     }
 
     public SurveyMethod getSurveyMethod(Survey survey, StagedRowFormatted stagedRow) {
-        boolean surveyNotDone = stagedRow.getCode().toLowerCase().equals("snd");
+        boolean surveyNotDone = stagedRow.getRef().getSpecies().toLowerCase().equals("Survey Not Done");
         Method method = entityManager.getReference(Method.class, stagedRow.getMethod());
         SurveyMethod surveyMethod = SurveyMethod.builder().survey(survey).method(method).blockNum(stagedRow.getBlock())
                 .surveyNotDone(surveyNotDone).build();
@@ -153,7 +153,7 @@ public class SurveyIngestionService {
 
         Stream<MeasureValue> unsized = Stream.empty();
 
-        if (!stagedRow.getCode().equalsIgnoreCase("snd") && stagedRow.getInverts() != null && stagedRow.getInverts() > 0) {
+        if (!stagedRow.getRef().getSpecies().equalsIgnoreCase("Survey Not Done") && stagedRow.getInverts() != null && stagedRow.getInverts() > 0) {
             unsized = Stream.of(new MeasureValue(0, stagedRow.getInverts()));
         }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
@@ -87,6 +87,15 @@ public class StagedRowFormatted {
                 && Objects.equals(species, that.species);
     }
 
+    
+    public Boolean isDebrisZero() {
+        return (code.equalsIgnoreCase("DEZ") || ref.getSpecies().equalsIgnoreCase("Debris - Zero"));
+    }
+
+    public Boolean isSurveyNotDone() {
+        return (code.equalsIgnoreCase("SND") || ref.getSpecies().equalsIgnoreCase("Survey Not Done"));
+    }
+
     public String getMethodBlock() {
         return method.toString() + '-' + block.toString();
     }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
@@ -89,11 +89,11 @@ public class StagedRowFormatted {
 
     
     public Boolean isDebrisZero() {
-        return (code.equalsIgnoreCase("DEZ") || ref.getSpecies().equalsIgnoreCase("Debris - Zero"));
+        return (code.equalsIgnoreCase("DEZ") || (ref != null && ref.getSpecies().equalsIgnoreCase("Debris - Zero")));
     }
 
     public Boolean isSurveyNotDone() {
-        return (code.equalsIgnoreCase("SND") || ref.getSpecies().equalsIgnoreCase("Survey Not Done"));
+        return (code.equalsIgnoreCase("SND") || (ref != null && ref.getSpecies().equalsIgnoreCase("Survey Not Done")));
     }
 
     public String getMethodBlock() {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -337,14 +337,14 @@ public class ValidationProcess {
         Integer observationTotal = row.getMeasureJson().entrySet().stream().map(Map.Entry::getValue).reduce(0, Integer::sum) + (row.getInverts() != null ? row.getInverts() : 0);
 
         // VALIDATION: RLS: Debris Zero observations
-        if (programName.equalsIgnoreCase("RLS") && row.getCode() != null && row.getCode().equalsIgnoreCase("dez") && row.getSpecies().isPresent()) {
+        if (programName.equalsIgnoreCase("RLS") && row.getCode() != null && row.isDebrisZero() && row.getSpecies().isPresent()) {
             if (!validateRowZeroOrOneInvertsTotal(row, observationTotal))
                 errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING, "Debris has Value/Total/Inverts not 0 or 1", row.getId(), "total"));
         }
 
         // VALIDATION: Record has no data and but not flagged as 'Survey Not Done' or
         // 'No Species Found'
-        if (observationTotal < 1 && row.getCode() != null && !row.getCode().equalsIgnoreCase("DEZ") && !row.getCode().equalsIgnoreCase("SND") && !(row.getSpecies().isPresent() &&  row.getSpecies().get().getObsItemType() != null  && row.getSpecies().get().getObsItemType().getObsItemTypeId() == OBS_ITEM_TYPE_NO_SPECIES_FOUND)) {
+        if (observationTotal < 1 && row.getCode() != null && !row.isDebrisZero() && !row.isSurveyNotDone() && !(row.getSpecies().isPresent() &&  row.getSpecies().get().getObsItemType() != null  && row.getSpecies().get().getObsItemType().getObsItemTypeId() == OBS_ITEM_TYPE_NO_SPECIES_FOUND)) {
             
             // VALIDATION: At least one value recorded in any of the size class columns or in the column Inverts
             if(row.getInverts() != null ) {
@@ -354,7 +354,7 @@ public class ValidationProcess {
             }
         } else if (row.getSpecies().isPresent() && row.getSpecies().get().getObsItemType() != null && row.getSpecies().get().getObsItemType().getObsItemTypeId() == OBS_ITEM_TYPE_NO_SPECIES_FOUND && !validateRowZeroOrOneInvertsTotal(row, observationTotal)){
             errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING, "'No Species Found' has Value/Total/Inverts not 0 or 1", row.getId(), "total"));
-        } else if (row.getCode() != null && row.getCode().equalsIgnoreCase("SND") && !validateRowZeroOrOneInvertsTotal(row, observationTotal)) {
+        } else if (row.isSurveyNotDone() && !validateRowZeroOrOneInvertsTotal(row, observationTotal)) {
             errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING, "'Survey Not Done' has Value/Total/Inverts not 0 or 1", row.getId(), "total"));
         }
         // VALIDATION: Abundance CheckSums

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -203,11 +203,9 @@ public class ValidationProcess {
                 }
 
             // Inverts
-            if (!StringUtils.isBlank(row.getInverts())) {
-                int inverts = NumberUtils.toInt(row.getInverts(), INVALID_INT);
-                if (inverts == INVALID_INT)
-                    errors.add(rowId, ValidationLevel.BLOCKING, "inverts", "Inverts is not an integer");
-            }
+            int inverts = NumberUtils.toInt(row.getInverts(), INVALID_INT);
+            if (inverts == INVALID_INT)
+                errors.add(rowId, ValidationLevel.BLOCKING, "inverts", "Inverts is not an integer");
 
             // Total
             if (NumberUtils.toInt(row.getTotal(), INVALID_INT) == INVALID_INT)

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -94,8 +94,10 @@ public class ValidationProcess {
         });
         Collection<ValidationRow> duplicateRows = new ArrayList<ValidationRow>();
         mappedRows.forEach((r, v) -> {
-            if (v.size() > 1)
-                duplicateRows.add(new ValidationRow(r, v, ValidationLevel.WARNING, "Rows duplicated"));
+            if (v.size() > 1) {
+                List<Long> rowIds = v.stream().limit(50).collect(Collectors.toList());
+                duplicateRows.add(new ValidationRow(r, rowIds, ValidationLevel.DUPLICATE, "Rows duplicated"));
+            }
         });
         return duplicateRows;
     }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -146,7 +146,8 @@ public class SurveyIngestionServiceTest {
         Method theMethod = Method.builder().methodId(2).methodName("The Method").isActive(true).build();
         when(entityManager.getReference(Method.class, 2)).thenReturn(theMethod);
         when(surveyMethodRepository.save(any())).then(s -> s.getArgument(0));
-        StagedRowFormatted row = rowBuilder.code("snd").build();
+        StagedRow inputRow = StagedRow.builder().species("Survey Not Done").build();
+        StagedRowFormatted row = rowBuilder.ref(inputRow).build();
         Survey survey = Survey.builder().surveyId(1).build();
         SurveyMethod surveyMethod = surveyIngestionService.getSurveyMethod(survey, row);
         assertEquals(true, surveyMethod.getSurveyNotDone());
@@ -308,7 +309,8 @@ public class SurveyIngestionServiceTest {
 
         Program program = Program.builder().programId(1).build();
         StagedJob stagedJob = StagedJob.builder().id(1L).program(program).build();
-        StagedRow stagedRow = StagedRow.builder().stagedJob(stagedJob).build();
+        StagedRow stagedRow = StagedRow.builder().stagedJob(stagedJob).species("Survey Not Done").build();
+
         StagedRowFormatted formattedRow = StagedRowFormatted
                 .builder()
                 .ref(stagedRow)

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/DuplicateRowCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/DuplicateRowCheckTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import au.org.aodn.nrmn.restapi.dto.stage.ValidationError;
 import au.org.aodn.nrmn.restapi.model.db.StagedRow;
+import au.org.aodn.nrmn.restapi.model.db.enums.ValidationLevel;
 import au.org.aodn.nrmn.restapi.repository.DiverRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -50,7 +51,7 @@ class DuplicateRowCheckTest {
         }}).build();
 
         Collection<ValidationError> res = validationProcess.checkFormatting("ATRC", false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
-        assertTrue(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Rows duplicated")));
+        assertTrue(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 
     @Test
@@ -71,7 +72,7 @@ class DuplicateRowCheckTest {
         }}).build();
 
         Collection<ValidationError> res = validationProcess.checkFormatting("ATRC", false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
-        assertTrue(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Rows duplicated")));
+        assertTrue(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 
     @Test
@@ -90,6 +91,6 @@ class DuplicateRowCheckTest {
         }}).build();
 
         Collection<ValidationError> res = validationProcess.checkFormatting("ATRC", false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
-        assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Rows duplicated")));
+        assertFalse(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/MissingDataCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/MissingDataCheckTest.java
@@ -19,6 +19,7 @@ class MissingDataCheckTest extends FormattedTestProvider {
     public void noSpeciesFoundWithNoObservationsShouldSucceed() {
         StagedRowFormatted formatted = getDefaultFormatted().build();
         formatted.setMeasureJson(ImmutableMap.<Integer, Integer>builder().build());
+        formatted.setInverts(0);
         formatted.setTotal(0);
         formatted.setCode("nsf");
 
@@ -34,6 +35,7 @@ class MissingDataCheckTest extends FormattedTestProvider {
     public void sndWithNoObservationsShouldSucceed() {
         StagedRowFormatted formatted = getDefaultFormatted().build();
         formatted.setMeasureJson(ImmutableMap.<Integer, Integer>builder().build());
+        formatted.setInverts(0);
         formatted.setTotal(0);
         formatted.setCode("snd");
         formatted.setSpecies(Optional.of(ObservableItem.builder().observableItemName("Survey Not Done").build()));

--- a/ui/src/components/import/panel/ValidationPanel.js
+++ b/ui/src/components/import/panel/ValidationPanel.js
@@ -44,7 +44,7 @@ const generateErrorSummary = (ctx, e) => {
         const existingIdx = acc.findIndex((m) => m.columnName === val.columnName && m.value === val.value);
         if (existingIdx >= 0) {
           const rowIds = acc[existingIdx].rowIds;
-          acc[existingIdx] = {...val, rowIds: [...rowIds, val.rowId]};
+          if (rowIds.length < 50) acc[existingIdx] = {...val, rowIds: [...rowIds, val.rowId]};
         } else {
           const rowIds = [val.rowId];
           delete val.rowId;

--- a/ui/src/components/import/panel/ValidationSummary.js
+++ b/ui/src/components/import/panel/ValidationSummary.js
@@ -59,7 +59,7 @@ const ValidationSummary = (props) => {
           }
           key={m.key}
         >
-          {m.description.map((d) => {
+          {m.description.slice(0, 50).map((d) => {
             const mmHeader = mm.find((m) => m.field === d.columnName);
             let label = mmHeader ? `${mmHeader.fishSize}/${mmHeader.invertSize}` : d.columnName;
             return (
@@ -72,9 +72,9 @@ const ValidationSummary = (props) => {
                   <div className={classes.labelRoot}>
                     <Typography key={i++} variant="body2" className={classes.labelText}>
                       {d.value ? (
-                        <div>
+                        <span>
                           <b>{label}</b> {d.value}
-                        </div>
+                        </span>
                       ) : d.label ? (
                         <b>{label} is empty</b>
                       ) : d.columnNames ? (

--- a/ui/src/components/layout/SideMenu.js
+++ b/ui/src/components/layout/SideMenu.js
@@ -52,8 +52,7 @@ const SideMenu = ({entities, open, onClose}) => {
       </List>
       <List>
         <Divider />
-        {version && <ListSubheader>{`Version ${version[0]}.${version[1]}`}</ListSubheader>}
-        <small>Build {version[2]}</small>
+        {version && <ListSubheader>{`Version ${version[0]}.${version[1]} (${version[2]})`}</ListSubheader>}
       </List>
     </Drawer>
   );

--- a/ui/src/components/layout/SideMenu.js
+++ b/ui/src/components/layout/SideMenu.js
@@ -53,6 +53,7 @@ const SideMenu = ({entities, open, onClose}) => {
       <List>
         <Divider />
         {version && <ListSubheader>{`Version ${version[0]}.${version[1]}`}</ListSubheader>}
+        <small>Build {version[2]}</small>
       </List>
     </Drawer>
   );


### PR DESCRIPTION
- Require inverts to be an integer
- Show all duplicate rows numbers in tooltip and change highlight to blue
- If either species name or code match Debris Zero or Survey Not Found than validate row as such
- Use species name not code to determine SND and DEZ
- Display the build number under the version