### PR TITLE
Remove limits from Debris Zero and Duplicate Row validations

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <artifactId>nrmn</artifactId>
         <groupId>au.org.aodn.nrmn</groupId>
-        <version>1.0.384</version>
+        <version>1.1.384</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>au.org.aodn.nrmn</groupId>

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/StagedJobController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/StagedJobController.java
@@ -158,7 +158,7 @@ public class StagedJobController {
                 if (rowsToTruncate.isPresent() && rowsToTruncate.get().getRowIds().size() >= 3) {
                     Collection<Long> rowIdsToRemove = rowsToTruncate.get().getRowIds();
                     // keep the last row if the data should finish with a true zero
-                    if (Arrays.asList("SURVEY NOT DONE", "DEBRIS - ZERO", "NO SURVEY FOUND").contains(lastRow.getSpecies().toUpperCase()))
+                    if (Arrays.asList("SURVEY NOT DONE", "DEBRIS - ZERO", "NO SPECIES FOUND").contains(lastRow.getSpecies().toUpperCase()))
                         rowIdsToRemove.remove(lastRowId);
                     rowsToSave.removeIf(r -> rowIdsToRemove.contains(r.getId()));
                 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -95,7 +95,7 @@ public class ValidationProcess {
         Collection<ValidationRow> duplicateRows = new ArrayList<ValidationRow>();
         mappedRows.forEach((r, v) -> {
             if (v.size() > 1) {
-                List<Long> rowIds = v.stream().limit(50).collect(Collectors.toList());
+                List<Long> rowIds = v.stream().collect(Collectors.toList());
                 duplicateRows.add(new ValidationRow(r, rowIds, ValidationLevel.DUPLICATE, "Rows duplicated"));
             }
         });
@@ -336,9 +336,8 @@ public class ValidationProcess {
 
         Integer observationTotal = row.getMeasureJson().entrySet().stream().map(Map.Entry::getValue).reduce(0, Integer::sum) + (row.getInverts() != null ? row.getInverts() : 0);
 
-        // VALIDATION: RLS: Debris Zero observations
-        if (programName.equalsIgnoreCase("RLS") && row.isDebrisZero() && row.getSpecies().isPresent()) {
-            if (!validateRowZeroOrOneInvertsTotal(row, observationTotal))
+        // VALIDATION: Debris Zero observations
+        if (row.isDebrisZero() && !validateRowZeroOrOneInvertsTotal(row, observationTotal)) {
                 errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING, "Debris has Value/Total/Inverts not 0 or 1", row.getId(), "total"));
         }
 

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>nrmn</artifactId>
         <groupId>au.org.aodn.nrmn</groupId>
-        <version>1.0.384</version>
+        <version>1.1.384</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>nrmn-app</artifactId>
@@ -19,13 +19,13 @@
         <dependency>
             <groupId>au.org.aodn.nrmn</groupId>
             <artifactId>nrmn-api</artifactId>
-            <version>1.0.384</version>
+            <version>1.1.384</version>
             <type>war</type>
          </dependency>
         <dependency>
             <groupId>au.org.aodn.nrmn</groupId>
             <artifactId>nrmn-ui</artifactId>
-            <version>1.0.384</version>
+            <version>1.1.384</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>au.org.aodn.nrmn</groupId>
     <artifactId>nrmn</artifactId>
-    <version>1.0.384</version>
+    <version>1.1.384</version>
     <packaging>pom</packaging>
     <name>nrmn</name>
     <description>Project for the NRMN database</description>

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>nrmn</artifactId>
         <groupId>au.org.aodn.nrmn</groupId>
-        <version>1.0.384</version>
+        <version>1.1.384</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>nrmn-ui</artifactId>


### PR DESCRIPTION
Remove limit of 50 rows from duplicate validation
Remove RLS limit from Debris Zero check so it will apply to ATRC as well.