### PR TITLE
Fix lowercase inside_marine_park values

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -118,7 +118,7 @@ public class SurveyIngestionService {
                         .visibility(stagedRow.getVis().orElse(null))
                         .program(stagedRow.getRef().getStagedJob().getProgram())
                         .protectionStatus(site.getProtectionStatus())
-                        .insideMarinePark(StringUtils.isNotBlank(site.getMpa()) ? "yes" : "no")
+                        .insideMarinePark(StringUtils.isNotBlank(site.getMpa()) ? "Yes" : "No")
                         .longitude(stagedRow.getLongitude())
                         .latitude(stagedRow.getLatitude())
                         .pqDiverId(stagedRow.getPqs() != null ? stagedRow.getPqs().getDiverId() : null)

--- a/scripts/db-update/04-lowercase_inside_marine_park.sql
+++ b/scripts/db-update/04-lowercase_inside_marine_park.sql
@@ -1,2 +1,4 @@
--- UI was setting the value of inside_marine_park to uppercase Yes, No, or Unsure.
-UPDATE nrmn.survey SET inside_marine_park=LOWER(inside_marine_park) WHERE inside_marine_park <> LOWER(inside_marine_park);
+-- UI was setting the value of inside_marine_park to lowercase instead of uppercase values
+UPDATE nrmn.survey SET inside_marine_park='Yes' where inside_marine_park = 'yes';
+UPDATE nrmn.survey SET inside_marine_park='No' where inside_marine_park = 'no';
+UPDATE nrmn.survey SET inside_marine_park='Unsure' where inside_marine_park = 'unsure';

--- a/scripts/db-update/04-lowercase_inside_marine_park.sql
+++ b/scripts/db-update/04-lowercase_inside_marine_park.sql
@@ -1,0 +1,2 @@
+-- UI was setting the value of inside_marine_park to uppercase Yes, No, or Unsure.
+UPDATE nrmn.survey SET inside_marine_park=LOWER(inside_marine_park) WHERE inside_marine_park <> LOWER(inside_marine_park);

--- a/ui/src/components/data-entities/EntityEdit.js
+++ b/ui/src/components/data-entities/EntityEdit.js
@@ -111,9 +111,9 @@ const EntityEdit = ({entity, template, clone}) => {
         entity: key,
         optional: true,
         values: [
-          {id: 'yes', label: 'yes'},
-          {id: 'no', label: 'no'},
-          {id: 'unsure', label: 'unsure'}
+          {id: 'Yes', label: 'Yes'},
+          {id: 'No', label: 'No'},
+          {id: 'Unsure', label: 'Unsure'}
         ]
       };
     } else if (key === 'supersededBy') {


### PR DESCRIPTION
Migrated data stored the "inside marine park" value as 'Yes', 'No' or 'Unsure'. The API ingest code is storing as 'yes', 'no', or 'unsure'.

This PR changes the ingest to match the uppercase migrated values and includes a script to update previously edited values.