### PR TITLE
Upgrade version of bumpversion

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN wget -q https://bootstrap.pypa.io/pip/3.5/get-pip.py \
     && rm -rf get-pip.py
 	
 RUN pip install \
-    bump2version==0.5.10
+    bump2version==1.0.1
 
 RUN useradd --create-home --no-log-init --shell /bin/bash --uid $BUILDER_UID builder
 USER builder


### PR DESCRIPTION
old version didn't support glob format

Part of https://github.com/aodn/backlog/issues/2616