### PR TITLE
Survey Template Export Narrowing Filter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+*.csv  -diff
+*.xls  -diff
+*.xlsx -diff

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/LocationController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/LocationController.java
@@ -1,6 +1,6 @@
 package au.org.aodn.nrmn.restapi.controller;
 
-import java.util.Collection;
+import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,8 +20,8 @@ public class LocationController {
     private LocationRepository locationRepository;
     
     @GetMapping("/locationList")
-    public Collection<LocationExtendedMapping> getLocationsWithRegions() {
-        Collection<LocationExtendedMapping> locations = locationRepository.getAllWithRegions();
+    public List<LocationExtendedMapping> getLocationsWithRegions() {
+        List<LocationExtendedMapping> locations = locationRepository.getAllWithRegions();
         return locations;
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/TemplateController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/TemplateController.java
@@ -29,15 +29,11 @@ public class TemplateController {
 
     @GetMapping(path = "/template.zip", produces = "application/zip")
     public void getTemplateZip(final HttpServletResponse response,
-                               @RequestParam(defaultValue = "") List<Integer> locations,
-                               @RequestParam(defaultValue = "") List<String> provinces,
-                               @RequestParam(defaultValue = "") List<String> states,
-                               @RequestParam(defaultValue = "") List<String> countries,
-                               @RequestParam(defaultValue = "") List<String> siteCodes) throws IOException {
+                               @RequestParam(defaultValue = "") List<Integer> locations) throws IOException {
         logger.info(LogInfo.withContext(String.format("downloading template zip")));
 
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        templateService.writeZip(outputStream, locations, provinces, states, countries, siteCodes);
+        templateService.writeZip(outputStream, locations);
 
         try {
             response.getOutputStream().write(outputStream.toByteArray());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/LocationRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/LocationRepository.java
@@ -1,6 +1,6 @@
 package au.org.aodn.nrmn.restapi.repository;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.domain.Page;
@@ -36,11 +36,12 @@ public interface LocationRepository extends JpaRepository<Location, Integer>, Jp
         "CASE loc.is_active WHEN true THEN 'Active' ELSE 'Inactive' END as status, " +
         "string_agg(DISTINCT sit.country, ', ' ORDER BY sit.country) AS countries, "+
         "string_agg(DISTINCT sit.state, ', ' ORDER BY sit.state) AS areas, "+
+        "string_agg(DISTINCT sit.site_code, ', ' ORDER BY sit.site_code) AS siteCodes, " +
         "string_agg(DISTINCT meo.ecoregion, ', ' ORDER BY meo.ecoregion) AS ecoRegions "+
         "FROM nrmn.location_ref loc " +
         "LEFT JOIN nrmn.site_ref sit ON loc.location_id = sit.location_id " +
         "LEFT JOIN nrmn.meow_ecoregions meo ON st_contains(meo.geom, sit.geom) " +
         "LEFT JOIN nrmn.survey sur ON sur.site_id = sit.site_id " +
         "GROUP BY loc.location_id, locationName", nativeQuery = true)
-    Collection<LocationExtendedMapping> getAllWithRegions();
+    List<LocationExtendedMapping> getAllWithRegions();
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/LocationExtendedMapping.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/LocationExtendedMapping.java
@@ -7,4 +7,5 @@ public interface LocationExtendedMapping {
     String getAreas();
     String getEcoRegions();
     String getStatus();
+    String getSiteCodes();
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/TemplateServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/TemplateServiceTest.java
@@ -144,24 +144,22 @@ public class TemplateServiceTest {
         Site testSite337 = builder.siteCode("QLD337").state("Queensland").country("Australia")
                 .location(Location.builder().locationId(337).locationName("Northish").build()).build();
 
-        when(siteRepository.findSiteCodesByProvince("Antipodes")).thenReturn(Arrays.asList("TAS333"));
-        when(siteRepository.findAll(Example.of(Site.builder().siteCode("TAS333").build())))
+        when(siteRepository.findAll(Example.of(Site.builder().location(Location.builder().locationId(333).build()).build())))
                 .thenReturn(Arrays.asList(testSite333));
 
-        when(siteRepository.findAll(Example.of(Site.builder().siteCode("TAS334").build())))
+        when(siteRepository.findAll(Example.of(Site.builder().location(Location.builder().locationId(334).build()).build())))
                 .thenReturn(Arrays.asList(testSite334));
 
         when(siteRepository.findAll(Example.of(Site.builder().location(Location.builder().locationId(335).build()).build())))
                         .thenReturn(Arrays.asList(testSite335));
 
-        when(siteRepository.findAll(Example.of(Site.builder().state("Victoria").build())))
+        when(siteRepository.findAll(Example.of(Site.builder().location(Location.builder().locationId(336).build()).build())))
                 .thenReturn(Arrays.asList(testSite336));
 
-        when(siteRepository.findAll(Example.of(Site.builder().country("Australia").build())))
+        when(siteRepository.findAll(Example.of(Site.builder().location(Location.builder().locationId(337).build()).build())))
                 .thenReturn(Arrays.asList(testSite337));
 
-        Set<Site> sites = templateService.getSitesForTemplate(Arrays.asList(335), Arrays.asList("Antipodes"),
-                Arrays.asList("Victoria"), Arrays.asList("Australia"), Arrays.asList("TAS334"));
+        Set<Site> sites = templateService.getSitesForTemplate(Arrays.asList(333,334,335,336,337));
 
         assertEquals(5, sites.size());
         assert (sites.contains(testSite333));

--- a/ui/pom.xml
+++ b/ui/pom.xml
@@ -85,6 +85,11 @@
                         </goals>
                         <configuration>
                             <outputDirectory>${basedir}/target/classes/static</outputDirectory>
+                            <nonFilteredFileExtensions>
+                              <nonFilteredFileExtension>xls</nonFilteredFileExtension>
+                              <nonFilteredFileExtension>xlsx</nonFilteredFileExtension>
+                              <nonFilteredFileExtension>csv</nonFilteredFileExtension>
+                            </nonFilteredFileExtensions>
                             <resources>
                                 <resource>
                                     <directory>build</directory>

--- a/ui/src/components/data-entities/location/LocationList.js
+++ b/ui/src/components/data-entities/location/LocationList.js
@@ -74,11 +74,6 @@ const LocationList = ({filterModel, setFilterModel}) => {
                 setRedirect(`${e.data.id}/edit`);
               }
             }}
-            onFilterChanged={(e) => {
-              const filterModel = e.api.getFilterModel();
-              setFilterModel('Location', filterModel);
-              setResetFilterDisabled(Object.keys(filterModel)?.length < 1);
-            }}
           />
           <AgGridColumn
             flex={1}


### PR DESCRIPTION
- Change zip export API to only require location ID.
- Change location mapping so the UI can map all ecoregion,  country, area and site code to location ID.
- Change the UI to display a collection of locations for the intersection of eco region, country and area.
- Add a site code drop-down to add the associated location id to the displayed group of locations.
- Allow the user to pick some or all of the filtered locations and export an associated survey template zip.

Also adds a gitattributes filter containing test data file extensions to (potentially) speed up diffs.