### PR TITLE
Species Epithet: Change search prefill behaviour and allow empty values

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/observableitem/ObservableItemDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/observableitem/ObservableItemDto.java
@@ -46,7 +46,6 @@ public class ObservableItemDto {
     private String genus;
 
     @Schema(title = "Species Epithet")
-    @NotNull(message =  "Species Epithet is required.")
     private String speciesEpithet;
 
     @Schema(title = "Letter Code")

--- a/ui/src/components/data-entities/form-reducer.js
+++ b/ui/src/components/data-entities/form-reducer.js
@@ -56,8 +56,12 @@ const formSlice = createSlice({
       state.data = {...state.data, ...action.payload};
     },
     selectedItemsLoaded: (state, action) => {
-      if(!('_embedded' in action.payload)) {
-        action.payload['_embedded'] = {'.': action.payload.map(item => { return {'.': item};} )};
+      if (!('_embedded' in action.payload)) {
+        action.payload['_embedded'] = {
+          '.': action.payload.map((item) => {
+            return {'.': item};
+          })
+        };
       }
       const key = Object.keys(action.payload._embedded)[0];
       const newOptions = {};
@@ -95,9 +99,17 @@ const formSlice = createSlice({
     searchFound: (state, action) => {
       if (action.payload?.length > 0)
         state.searchResults = action.payload.map((r, id) => {
-          // remove the genus from the species to produce the species epithet
-          const speciesEpithet = r.species ? r.species.replace(`${r.genus} `, '') : '';
-          return {id: id, ...r, speciesEpithet: speciesEpithet};
+          // if not a generic name then remove the genus from the species to produce the species epithet
+          let speciesEpithet = '';
+          if (r.species) {
+            const isGenericName =
+              r.species.toUpperCase().includes('SP.') ||
+              r.species.toUpperCase().includes('SPP.') ||
+              r.species.includes('(') ||
+              r.species.includes('[');
+            if (!isGenericName) speciesEpithet = r.species.replace(`${r.genus} `, '');
+          }
+          return {id: id, ...r, speciesEpithet};
         });
       else state.searchResults = [];
       state.loading = false;


### PR DESCRIPTION
Only prefill from search if species does not contain spp. or parens.
Remove nonnull constraint and validation.