### PR TITLE
Bump log4j version to 2.15.0

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -419,7 +419,7 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.13.3</version>
+            <version>2.15.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Necessary due to CVE-2021-44228.