### PR TITLE
Improve survey coordinate validation

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -400,16 +400,18 @@ public class ValidationProcess {
         return null;
     }
 
-    // VALIDATION: Survey coordinates match with DB
-    private Collection<ValidationCell> validateWithin200M(StagedRowFormatted row) {
+    // VALIDATION: Survey coordinates match site coordinates
+    private Collection<ValidationCell> validateSurveyAtSite(StagedRowFormatted row) {
         Collection<ValidationCell> errors = new ArrayList<ValidationCell>();
 
         if(row.getSite() == null || row.getSite().getLatitude() == null || row.getSite().getLongitude() == null ||  row.getLatitude() == null || row.getLongitude() == null)
             return errors;
 
         double dist = getDistance(row.getSite().getLatitude(), row.getSite().getLongitude(), row.getLatitude(), row.getLongitude());
-        if (dist > 0.2) {
-            String message = "Coordinates are further than 0.2km from the Site (" + String.format("%.2f", dist) + "km)";
+
+        // Survey coordinates differ from site location by ~1m
+        if (dist > 0.000001) {
+            String message = "Coordinates differ from Site (" + String.format("%.4f", dist) + "km)";
             errors.add(new ValidationCell(ValidationCategory.SPAN, ValidationLevel.WARNING, message, row.getId(), "latitude"));
             errors.add(new ValidationCell(ValidationCategory.SPAN, ValidationLevel.WARNING, message, row.getId(), "longitude"));
         }
@@ -622,8 +624,8 @@ public class ValidationProcess {
             // Row Method is valid for species
             results.add(validateSpeciesBelowToMethod(row), false);
 
-            // Validate within 200M
-            results.addAll(validateWithin200M(row), false);
+            // Validate survey is at site location
+            results.addAll(validateSurveyAtSite(row), false);
 
             // Validate M3, M4 and M5 rows have zero inverts
             results.add(validateInvertsZeroOnM3M4M5(row), false);

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/SurveyAtSiteTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/SurveyAtSiteTest.java
@@ -12,27 +12,24 @@ import au.org.aodn.nrmn.restapi.dto.stage.ValidationError;
 import au.org.aodn.nrmn.restapi.model.db.Site;
 import au.org.aodn.nrmn.restapi.validation.StagedRowFormatted;
 
-class Within200MSiteCheckTest extends FormattedTestProvider {
+class SurveyAtSiteTest extends FormattedTestProvider {
 
     @Test
-    void within200MShouldSuccess() {
+    void sameCoordsShouldSucceed() {
         StagedRowFormatted formatted = getDefaultFormatted().build();
 
-        // Hobart IMAS: -42.886410468013004, 147.33520415427964
-        formatted.setLatitude( -42.886410468013004);
+        formatted.setLatitude(-42.886410468013004);
         formatted.setLongitude(147.33520415427964);
 
-        //Hobart Blue Eye SeaFood: 42.88654698514, 147.33479357370092
-        formatted.setSite(Site.builder().siteCode("A SITE").latitude( -42.88654698514).longitude(147.33479357370092).build());
+        formatted.setSite(Site.builder().siteCode("A SITE").latitude( -42.886410468013004).longitude(147.33520415427964).build());
         Collection<ValidationError> errors = validationProcess.checkData("ATRC", false, Arrays.asList(formatted));
-        assertFalse(errors.stream().anyMatch(p -> p.getMessage().contains("Coordinates are further than 0.2km from the Site")));
+        assertFalse(errors.stream().anyMatch(p -> p.getMessage().startsWith("Coordinates differ")));
     }
 
     @Test
-    void outside200MShouldFail() {
+    void differentCoordsShouldFail() {
         StagedRowFormatted formatted = getDefaultFormatted().build();
         formatted.setMethod(1);
-        // formatted.setSpecies(Optional.of(ObservableItem.builder().observableItemName("THE SPECIES").methods(methods).build()));
 
         //hobart IMAS -42.886410468013004, 147.33520415427964
         formatted.setLatitude( -42.886410468013004);
@@ -44,7 +41,7 @@ class Within200MSiteCheckTest extends FormattedTestProvider {
                 .longitude(147.3293531695972).build());
 
         Collection<ValidationError> errors = validationProcess.checkData("ATRC", false, Arrays.asList(formatted));
-        assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Coordinates are further than 0.2km from the Site")));
+        assertTrue(errors.stream().anyMatch(p -> p.getMessage().startsWith("Coordinates differ")));
     }
 
 }

--- a/ui/src/components/data-entities/SiteEdit.js
+++ b/ui/src/components/data-entities/SiteEdit.js
@@ -62,6 +62,8 @@ const SiteEdit = ({clone}) => {
     }
   };
 
+  useEffect(latLongBlur, [site.latitude, site.longitude]);
+
   useEffect(() => {
     if (checkCoords && !isNaN(parseFloat(site.latitude)) && !isNaN(parseFloat(site.longitude))) {
       const query = `sitesAroundLocation?latitude=${site.latitude}&longitude=${site.longitude}` + (edit ? `&exclude=${siteId}` : '');


### PR DESCRIPTION
- Datasheet: Display the coordinate validation if the distance between survey and site is greater than about 1m
- Site Clone: Show the coordinate validation warning immediately on page load instead of waiting for coords to be edited