### PR TITLE
Diver: Convert name to ASCII for validation and lookup

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/DiverController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/DiverController.java
@@ -22,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -89,7 +90,8 @@ public class DiverController {
                     "A diver with these initials already exists."));
         }
 
-        List<Diver> existingDiversWithSameName = diverRepository.findByFullName(diver.getFullName());
+        String diverFullName = Normalizer.normalize(diver.getFullName(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "");
+        List<Diver> existingDiversWithSameName = diverRepository.findByFullName(diverFullName);
 
         if(diver.getDiverId() != null) {
             existingDiversWithSameName = existingDiversWithSameName

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
@@ -1,5 +1,6 @@
 package au.org.aodn.nrmn.restapi.controller.mapping;
 
+import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
@@ -32,7 +33,7 @@ public class StagedRowFormattedMapperConfig {
             if (ctx.getSource() == null)
                 return null;
             Optional<Diver> diver = divers.stream()
-                    .filter(d -> (d.getFullName() != null && d.getFullName().equalsIgnoreCase(ctx.getSource()))
+                    .filter(d -> (d.getFullName() != null && Normalizer.normalize(d.getFullName(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "").equalsIgnoreCase(ctx.getSource()))
                             || (d.getInitials() != null && d.getInitials().equalsIgnoreCase(ctx.getSource())))
                     .findFirst();
             return diver.isPresent() ? diver.get() : null;

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/DiverExistsIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/DiverExistsIT.java
@@ -48,7 +48,18 @@ class DiverExistsIT {
         job.setId(1L);
         StagedRow row = new StagedRow();
         row.setStagedJob(job);
-        row.setDiver("TJR");
+        row.setDiver("JEP");
+        Collection<ValidationError> res = validationProcess.checkFormatting("ATRC", false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        assertFalse(res.stream().anyMatch(e -> e.getColumnNames().contains("diver") && e.getMessage().equalsIgnoreCase("Diver does not exist")));
+    }
+
+    @Test
+    void diverNameWithAccentShouldBeOk() {
+        StagedJob job = new StagedJob();
+        job.setId(1L);
+        StagedRow row = new StagedRow();
+        row.setStagedJob(job);
+        row.setDiver("Juán Español Página");
         Collection<ValidationError> res = validationProcess.checkFormatting("ATRC", false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertFalse(res.stream().anyMatch(e -> e.getColumnNames().contains("diver") && e.getMessage().equalsIgnoreCase("Diver does not exist")));
     }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/StagedRowFormattedMappingIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/StagedRowFormattedMappingIT.java
@@ -55,7 +55,7 @@ class StagedRowFormattedMappingIT {
         row.setLatitude("-35");
         row.setDate("16/11/2020");
         row.setTime("11:32");
-        row.setDiver("TJR");
+        row.setDiver("JEP");
         row.setDepth("7.4");
         row.setMethod("1");
         row.setBlock("1");
@@ -85,8 +85,8 @@ class StagedRowFormattedMappingIT {
         assertEquals(-35, formattedRow.getLatitude());
         assertEquals(LocalDate.parse("16/11/2020", DateTimeFormatter.ofPattern("d/M/yyyy")), formattedRow.getDate());
         assertEquals(TimeUtils.parseTime("11:32"), formattedRow.getTime());
-        assertEquals("TJR", formattedRow.getDiver().getInitials());
-        assertEquals("Tanjona Julien Rafidison", formattedRow.getDiver().getFullName());
+        assertEquals("JEP", formattedRow.getDiver().getInitials());
+        assertEquals("Juan Espanol Pagina", formattedRow.getDiver().getFullName());
         assertEquals(1, formattedRow.getBlock());
         assertEquals(Directions.NE, formattedRow.getDirection());
         assertEquals(102, formattedRow.getSpecies().get().getAphiaId());

--- a/api/src/test/resources/testdata/FILL_DATA.sql
+++ b/api/src/test/resources/testdata/FILL_DATA.sql
@@ -59,7 +59,7 @@ VALUES (55, 551, 812331345, '2017-11-28', '00:00:00', 25, 1, 10, 'N',
 
 
 INSERT INTO nrmn.diver_ref(diver_id, initials, full_name)
-VALUES (51, 'TJR', 'Tanjona Julien Rafidison');
+VALUES (51, 'JEP', 'Juan Espanol Pagina');
 INSERT INTO nrmn.diver_ref(diver_id, initials, full_name)
 VALUES (70, 'AZS', 'Alex Zum Smith');
 INSERT INTO nrmn.diver_ref(diver_id, initials, full_name)
@@ -158,7 +158,7 @@ VALUES (551, 1, '{}',51, 3, 333,121),
 INSERT INTO nrmn.staged_row(pqs, block, buddy, code, created, date, depth, direction, diver,
                             inverts, is_invert_sizing, last_updated, latitude, longitude, 
                             measure_value, method, site_name, site_no, species, time, total, vis, staged_job_id)
-VALUES ('TJR', 1, 'AZS', 'AAA', '09/09/2009', '03/03/2003', 3.3, 'NW', 'TJR',
+VALUES ('JEP', 1, 'AZS', 'AAA', '09/09/2009', '03/03/2003', 3.3, 'NW', 'JEP',
         0, false, '01/01/2001', -5, 35, 
         '{
           "1": "5"


### PR DESCRIPTION
Converts all datasheet diver names to ASCII before performing validations.
eg. if a datasheet contains "Juán Página" it will match successfully with "Juan Pagina" in the database.