### PR TITLE
Survey Edit: Allow empty PQ diver

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyEditService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyEditService.java
@@ -77,8 +77,11 @@ public class SurveyEditService {
         survey.setDepth(Integer.valueOf(surveyDto.getDepth()));
         survey.setSurveyNum(surveyDto.getSurveyNum());
 
-        Diver pqDiver = diverRepository.findByCriteria(surveyDto.getPqDiverInitials()).get(0);
-        survey.setPqDiverId(pqDiver.getDiverId());
+        List<Diver> diver = diverRepository.findByCriteria(surveyDto.getPqDiverInitials());
+        if (diver.size() > 0) {
+          Diver pqDiver = diver.get(0);
+          survey.setPqDiverId(pqDiver.getDiverId());
+        }
 
         survey.setProjectTitle(surveyDto.getProjectTitle());
         survey.setProtectionStatus(surveyDto.getProtectionStatus());
@@ -123,7 +126,8 @@ public class SurveyEditService {
 
         // Time validations
         try {
-            parseTime(surveyDto.getSurveyTime());
+          if (StringUtils.isEmpty(surveyDto.getSurveyTime()))
+            surveyDto.getSurveyTime();
         } catch (DateTimeException e) {
             errors.add(new ValidationError("Survey", "surveyTime", surveyDto.getSurveyTime(),
                     "The survey time must be in the format hh:mm[:ss]"));

--- a/ui/src/components/data-entities/EntityEdit.js
+++ b/ui/src/components/data-entities/EntityEdit.js
@@ -138,6 +138,7 @@ const EntityEdit = ({entity, template, clone}) => {
     } else if (key === 'pqDiverInitials') {
       uiSchema[key] = {
         'ui:field': 'dropdown',
+        optional: true,
         route: 'divers',
         entity: 'diver',
         entityList: 'divers',


### PR DESCRIPTION
Editing a survey with an empty PQ diver fills in the first diver from the DB since the field is not nullable.
Change so that the field can handle empty PQ divers and also remove an existing diver.