### PR TITLE
Never group measurement column validations

### DIFF
--- a/ui/src/components/import/DataSheetView.js
+++ b/ui/src/components/import/DataSheetView.js
@@ -136,7 +136,7 @@ const generateErrorTree = (rowData, rowPos, errors) => {
           const rowPosition = rowData.find((d) => d.id === r.id)?.pos;
           const rowNumber = rowPos.indexOf(rowPosition) + 1;
           const existingIdx = acc.findIndex((m) => m.columnName === col && m.value === r[col]);
-          if (existingIdx >= 0)
+          if (existingIdx >= 0 && isNaN(parseInt(acc[existingIdx].columnName)))
             acc[existingIdx] = {
               columnName: col,
               value: r[col],

--- a/ui/src/components/import/panel/ValidationSummary.js
+++ b/ui/src/components/import/panel/ValidationSummary.js
@@ -12,14 +12,7 @@ const ValidationSummary = (props) => {
   const mm = measurements.concat(extendedMeasurements);
   return (
     <TreeView defaultCollapseIcon={<ArrowDropDownIcon />} defaultExpandIcon={<ArrowRightIcon />}>
-      {props.data
-      .filter(m => {
-        // HACK: Hide L5/L95 warnings without a size class
-        const isL5L95 = m?.message?.includes('Measurements outside L5');
-        const isMissingInverts = typeof m?.description[0]?.isInvertSize === 'undefined';
-        return isL5L95 && isMissingInverts ? false : true;
-      })
-      .map((m) => (
+      {props.data.map((m) => (
         <TreeItem
           key={m.key}
           nodeId={m.key}


### PR DESCRIPTION
Removes the hack to hide spurious validation message and instead fixes the error tree generator to never group measurement warnings.