### PR TITLE
Add source name normalisation to diver mapping

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
@@ -34,7 +34,7 @@ public class StagedRowFormattedMapperConfig {
             if (ctx.getSource() == null)
                 return null;
             Optional<Diver> diver = divers.stream()
-                    .filter(d -> (StringUtils.isNotEmpty(d.getFullName()) && d.getFullName().equalsIgnoreCase(Normalizer.normalize(ctx.getSource(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")))
+                    .filter(d -> (StringUtils.isNotEmpty(d.getFullName()) && Normalizer.normalize(d.getFullName(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "").equalsIgnoreCase(Normalizer.normalize(ctx.getSource(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")))
                             || (StringUtils.isNotEmpty(d.getInitials()) && d.getInitials().equalsIgnoreCase(ctx.getSource())))
                     .findFirst();
             Diver returnDiver = diver.isPresent() ? diver.get() : null;


### PR DESCRIPTION
Both source and destination diver names need to be normalised before comparison.