### PR TITLE
Survey visibility: Round to integer value

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -203,12 +203,11 @@ public class SurveyIngestionService {
     public void ingestTransaction(StagedJob job, Collection<StagedRowFormatted> validatedRows) {
 
         Map<String, List<StagedRowFormatted>> rowsGroupedBySurvey = validatedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurvey));
-        int scale = (int) Math.pow(10, 1);
         List<Integer> surveyIds = rowsGroupedBySurvey.values().stream().map(surveyRows -> {
             
             OptionalDouble visAvg = surveyRows.stream().filter(r -> r.getVis().isPresent()).mapToDouble(r -> r.getVis().get()).average();
             if(visAvg.isPresent())
-                visAvg = OptionalDouble.of((double) Math.round(visAvg.getAsDouble() * scale) / scale);
+                visAvg = OptionalDouble.of((double)Math.round(visAvg.getAsDouble()));
 
             Survey survey = getSurvey(job.getProgram(), visAvg, surveyRows.get(0));
             groupRowsByMethodBlock(surveyRows).values().forEach(methodBlockRows -> {

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -301,7 +301,7 @@ public class SurveyIngestionServiceTest {
     }
 
     @Test
-    void ingestSurveyNotDone() {
+    void ingestSurvey() {
         when(surveyRepository.save(any())).then(s -> s.getArgument(0));
         when(surveyMethodRepository.save(any())).then(s -> s.getArgument(0));
         when(observationRepository.saveAll(any())).then(s -> s.getArgument(0));
@@ -319,7 +319,7 @@ public class SurveyIngestionServiceTest {
                 .depth(10)
                 .surveyNum(1)
                 .direction(Directions.N)
-                .vis(Optional.of(2.75))
+                .vis(Optional.of(2.5))
                 .method(2)
                 .block(1)
                 .code("snd")
@@ -336,7 +336,7 @@ public class SurveyIngestionServiceTest {
                 .depth(10)
                 .surveyNum(1)
                 .direction(Directions.N)
-                .vis(Optional.of(2.75))
+                .vis(Optional.of(2.5))
                 .method(2)
                 .block(1)
                 .code("snd")
@@ -349,7 +349,7 @@ public class SurveyIngestionServiceTest {
         ArgumentCaptor<Survey> surveyCaptor = ArgumentCaptor.forClass(Survey.class);
         Mockito.verify(surveyRepository).save(surveyCaptor.capture());
         Survey survey = surveyCaptor.getValue();
-        assertEquals(2.8, survey.getVisibility());
+        assertEquals(3.0, survey.getVisibility());
 
         ArgumentCaptor<SurveyMethod> surveyMethodCaptor = ArgumentCaptor.forClass(SurveyMethod.class);
         Mockito.verify(surveyMethodRepository).save(surveyMethodCaptor.capture());


### PR DESCRIPTION
Still displaying and storing value as double since existing surveys have already been ingested with non-integer visibility values.