### PR TITLE
U: Fix JobList page size to 99

### DIFF
--- a/ui/src/components/job/JobList.js
+++ b/ui/src/components/job/JobList.js
@@ -13,7 +13,7 @@ const JobList = () => {
   const [deleteJobId, setDeleteJobId] = useState(null);
 
   useEffect(() => {
-    getEntity('stagedJobs').then((result) => {
+    getEntity('stagedJobs?size=99').then((result) => {
       // HACK: fix the api to return the correct format instead
       const stagedJobs = result.data?._embedded?.stagedJobs || [];
       const jobRows = stagedJobs.map((j) => {


### PR DESCRIPTION
Fix jobs not appearing in the list. Pagination is enabled and fixed at page size 20 on entities despite it not being supported in the UI. despite it not being supported in the UI.