### PR TITLE
Update web project path in Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
                 stage('clean') {
                     steps {
                         sh 'git reset --hard'
-                        sh 'git clean --force --force -xd --exclude=ui/node_modules'
+                        sh 'git clean --force --force -xd --exclude=web/node_modules'
                     }
                 }
                 stage('set_version_release') {


### PR DESCRIPTION
Build is taking ~10 minutes longer than it should because Git is deleting and re-downloading the node_modules every time.