### PR TITLE
Put back survey distance from site

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -415,8 +415,9 @@ public class ValidationProcess {
 
         // Warn if survey is more than 10 meters away from site
         if (distMeters > 10) {
-            errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING, "Survey coordinates are more than 10m from site coordinates", row.getId(), "latitude"));
-            errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING, "Survey coordinates are more than 10m from site coordinates", row.getId(), "longitude"));
+            String message = "Survey coordinates more than 10m from site (" + String.format("%.1f", distMeters) + "m)";
+            errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING, message, row.getId(), "latitude"));
+            errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING, message, row.getId(), "longitude"));
         }
         
         return errors;

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/test/PostgresqlContainerExtension.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/test/PostgresqlContainerExtension.java
@@ -15,7 +15,7 @@ public class PostgresqlContainerExtension implements Extension {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresqlContainerExtension.class);
     
-    private static final DockerImageName POSTGIS_IMAGE_NAME = DockerImageName.parse("mdillon/postgis:9.6").asCompatibleSubstituteFor("postgres");
+    private static final DockerImageName POSTGIS_IMAGE_NAME = DockerImageName.parse("mdillon/postgis:10").asCompatibleSubstituteFor("postgres");
 
     @Container
     static public PostgreSQLContainer<?> container = new PostgreSQLContainer<>(POSTGIS_IMAGE_NAME);


### PR DESCRIPTION
Survey validation should be displaying the distance from the site if greater than 10m.

I accidentally remove this from the message in the last PR.