### PR TITLE
Template Export: Filter by method before generating letter codes

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/LetterCodeRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/LetterCodeRepository.java
@@ -22,7 +22,8 @@ public interface LetterCodeRepository extends JpaRepository<Survey, Integer>, Jp
             + "INNER JOIN {h-schema}survey_method surmet ON surmet.survey_id = sur.survey_id "
             + "INNER JOIN {h-schema}observation obs ON obs.survey_method_id = surmet.survey_method_id "
             + "INNER JOIN {h-schema}observable_item_ref obsitem ON obsitem.observable_item_id = obs.observable_item_id "
-            + "WHERE site_raw.site_id in (:siteIds) "
+            + "INNER JOIN {h-schema}methods_species ms ON obsitem.observable_item_id = ms.observable_item_id "
+            + "WHERE site_raw.site_id in (:siteIds) AND ms.method_id = :methodId "
             + "GROUP BY obsitem.observable_item_id, species_name, common_name),"
             + "stage1 AS (SELECT *, {h-schema}abbreviated_species_code(species_name, 3) AS code_len3 FROM stage0),"
             + "stage2 AS (SELECT *, ROW_NUMBER() OVER (partition by code_len3 order by abundance desc) AS code_len3_rank FROM stage1),"
@@ -36,5 +37,5 @@ public interface LetterCodeRepository extends JpaRepository<Survey, Integer>, Jp
             + "FROM {h-schema}observable_item_ref oir JOIN stage7 s7 on s7.observable_item_id = oir.observable_item_id "
             + "JOIN {h-schema}obs_item_type_ref oitr ON oitr.obs_item_type_id = oir.obs_item_type_id "
             + "WHERE oitr.obs_item_type_id = ANY (ARRAY[1, 2]) ORDER BY letterCode", nativeQuery = true)
-    List<LetterCodeMapping> getForSiteIds(@Param("siteIds") List<Integer> siteIds);
+    List<LetterCodeMapping> getForMethodWithSiteIds(@Param("methodId") Integer methodId, @Param("siteIds") List<Integer> siteIds);
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/TemplateServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/TemplateServiceTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -439,12 +438,9 @@ public class TemplateServiceTest {
         when(observableItemRepository.getAllWithMethodForSites(2, siteIds))
                 .thenReturn(Arrays.asList(o1).stream().collect(Collectors.toList()));
         when(observationRepository.getSpeciesAttributesByIds(obsIds)).thenReturn(swaList);
-        when(letterCodeRepository.getForSiteIds(siteIds)).thenReturn(Arrays.asList(lcm1, lcm2, lcm3));
-        List<LetterCodeMapping> letterCodeMappings = letterCodeRepository.getForSiteIds(siteIds);
-        HashMap<Long, String> letterCodeMap = new HashMap<Long, String>();
-        letterCodeMappings.forEach(
-                m -> letterCodeMap.put(Long.valueOf(m.getObservableItemId()), m.getLetterCode()));
-        List<SpeciesWithAttributesCsvRow> speciesWithAttributes = templateService.getSpeciesForTemplate(2, siteIds, letterCodeMap);
+        when(letterCodeRepository.getForMethodWithSiteIds(2, siteIds)).thenReturn(Arrays.asList(lcm1, lcm2, lcm3));
+        List<SpeciesWithAttributesCsvRow> speciesWithAttributes = templateService.getSpeciesForTemplate(2, siteIds);
+        
         // Add one for 'survey not done' added by the service
         assertEquals(swaList.size() + 1, speciesWithAttributes.size());
         assertEquals("Abudefduf saxatilis", speciesWithAttributes.get(0).getSpeciesName());


### PR DESCRIPTION
Generate the letter code map on a per-method basis to fix long letter codes.