### PR TITLE
Use auth context to determinal admin role instead of hardcoded flag

### DIFF
--- a/web/src/components/import/DataSheetView.js
+++ b/web/src/components/import/DataSheetView.js
@@ -145,7 +145,7 @@ const generateErrorTree = (rowData, rowPos, errors) => {
 
 const IngestState = Object.freeze({Loading: 0, Edited: 1, Valid: 2, ConfirmSubmit: 3});
 
-const DataSheetView = ({onIngest}) => {
+const DataSheetView = ({onIngest, isAdmin}) => {
   const {id} = useParams();
   const [job, setJob] = useState({});
   const [gridApi, setGridApi] = useState();
@@ -444,6 +444,7 @@ const DataSheetView = ({onIngest}) => {
 
   const reload = (api, id, completion) => {
     resetContext();
+    context.isAdmin = isAdmin;
     getDataJob(id).then((res) => {
       const job = {
         program: res.data.job.program.programName,
@@ -685,7 +686,7 @@ const DataSheetView = ({onIngest}) => {
             <Box p={1} mr={2}>
               <Button
                 variant="contained"
-                disabled={state !== IngestState.Valid}
+                disabled={state !== IngestState.Valid && !isAdmin}
                 onClick={() => setState(IngestState.ConfirmSubmit)}
                 startIcon={<CloudUploadIcon />}
               >
@@ -797,7 +798,8 @@ const DataSheetView = ({onIngest}) => {
 };
 
 DataSheetView.propTypes = {
-  onIngest: PropTypes.func.isRequired
+  onIngest: PropTypes.func.isRequired,
+  isAdmin: PropTypes.bool.isRequired
 };
 
 export default DataSheetView;

--- a/web/src/components/import/ValidationJob.js
+++ b/web/src/components/import/ValidationJob.js
@@ -3,6 +3,7 @@ import {Navigate, useParams} from 'react-router';
 import {Box} from '@mui/material';
 import DataSheetView from './DataSheetView';
 import Alert from '@mui/material/Alert';
+import {AuthContext} from '../../contexts/auth-context';
 
 const ValidationJob = () => {
   const {id} = useParams();
@@ -13,17 +14,21 @@ const ValidationJob = () => {
   }
 
   return (
-    <>
-      {ingestState.data && (
-        <Box mx={2}>
-          <Alert severity="error" variant="outlined">
-            <p>Sheet failed to ingest. No survey data has been inserted.</p>
-            <p>Error: {ingestState.data}</p>
-          </Alert>
-        </Box>
+    <AuthContext.Consumer>
+      {({auth}) => (
+        <>
+          {ingestState.data && (
+            <Box mx={2}>
+              <Alert severity="error" variant="outlined">
+                <p>Sheet failed to ingest. No survey data has been inserted.</p>
+                <p>Error: {ingestState.data}</p>
+              </Alert>
+            </Box>
+          )}
+          <DataSheetView isAdmin={auth.roles.includes('ROLE_ADMIN')} jobId={id} onIngest={setIngestState} />;
+        </>
       )}
-      <DataSheetView jobId={id} onIngest={setIngestState} />
-    </>
+    </AuthContext.Consumer>
   );
 };
 

--- a/web/src/components/import/panel/ValidationPanel.js
+++ b/web/src/components/import/panel/ValidationPanel.js
@@ -7,9 +7,6 @@ const ValidationPanel = (props) => {
   const context = props.api.gridOptionsWrapper.gridOptions.context;
   const summary = context.summary;
   const errorList = context.errorList;
-  // FIXME:
-  // const isAdmin = useSelector((state) => state.auth.roles)?.includes('ROLE_ADMIN');
-  const isAdmin = false;
 
   const handleItemClick = (item, noFilter) => {
     const rowId = item.row || item.rowIds[0];
@@ -96,7 +93,7 @@ const ValidationPanel = (props) => {
           </TableBody>
         </Table>
       </Box>
-      {isAdmin ? (
+      {context.isAdmin ? (
         <Box m={2} mt={1}>
           <Typography style={{color: 'red'}} variant="button">
             Blocking validations disabled. Proceed with caution!

--- a/web/src/components/layout/AuthState.js
+++ b/web/src/components/layout/AuthState.js
@@ -21,7 +21,7 @@ const AuthState = () => {
           <>
             <Button variant="contained" disableElevation startIcon={<AccountCircle />} onClick={() => showConfirmLogout(true)}>
               {auth.username}
-              {auth.isAdmin && <span style={{color: 'yellow', marginLeft: 5}}>(ADMIN)</span>}
+              {auth.roles.includes('ROLE_ADMIN') && <span style={{color: 'yellow', marginLeft: 5}}>(ADMIN)</span>}
             </Button>
             <AlertDialog
               open={confirmLogout}


### PR DESCRIPTION
When removing Redux the isAdmin flag was changed temporarily to be a hardcoded boolean. This PR fixes this to use the AuthContext for checking roles.