### PR TITLE
Print survey with decimal depth in validation messages

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
@@ -107,4 +107,8 @@ public class StagedRowFormatted {
     public String getSurveyGroup() {
         return ref.getSurveyGroup();
     }
+
+    public String getDecimalSurvey() {
+        return String.format("[%s, %s, %s.%d]", getSite().getSiteCode(),  getDate(), getDepth(), getSurveyNum());
+    }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/StagedRowFormatted.java
@@ -109,6 +109,6 @@ public class StagedRowFormatted {
     }
 
     public String getDecimalSurvey() {
-        return String.format("[%s, %s, %s.%d]", getSite().getSiteCode(),  getDate(), getDepth(), getSurveyNum());
+        return String.format("[%s, %s, %s.%d]", getRef().getSiteCode(),  getDate(), getDepth(), getSurveyNum());
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/validation/process/ValidationProcess.java
@@ -498,7 +498,7 @@ public class ValidationProcess {
         missingMethods.removeAll(surveyByMethod.keySet());
         if(missingMethods.size() > 0) {
             List<String> missingMethodsList = missingMethods.stream().map(m -> m.toString()).collect(Collectors.toList());
-            messages.add(" missing M" + String.join(", M", missingMethodsList));
+            messages.add("missing M" + String.join(", M", missingMethodsList));
             rowIds.addAll(surveyRows.stream().map(r -> r.getId()).collect(Collectors.toList()));
             flagColumns.add("method");
         }
@@ -528,8 +528,7 @@ public class ValidationProcess {
         }
 
         if(messages.size() > 0) {
-            return new ValidationError(ValidationCategory.SPAN, level, messagePrefix + String.join(". ", messages), 
-            rowIds, flagColumns);
+            return new ValidationError(ValidationCategory.SPAN, level, messagePrefix + " " + String.join(". ", messages), rowIds, flagColumns);
         }
 
         return null;

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ATRCDepthValidationTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ATRCDepthValidationTest.java
@@ -54,7 +54,7 @@ class ATRCDepthValidationTest {
     job.setId(1L);
     StagedRowFormatted stage = new StagedRowFormatted();
     stage.setSurveyNum(9);
-    ValidationError error = validationProcess.validateSurveyTransectNumber("", Arrays.asList(stage));
+    ValidationError error = validationProcess.validateSurveyTransectNumber(Arrays.asList(stage));
     assertTrue(error.getMessage().equals("Survey group transect invalid"));
   }
 
@@ -66,7 +66,7 @@ class ATRCDepthValidationTest {
     row.setDepth(7);
     row.setSurveyNum(3);
     row.setMethod(1);
-    ValidationError error = validationProcess.validateSurveyTransectNumber("", Arrays.asList(row));
+    ValidationError error = validationProcess.validateSurveyTransectNumber(Arrays.asList(row));
     assertTrue(error == null);
   }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ATRCSurveyGroupCompleteIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ATRCSurveyGroupCompleteIT.java
@@ -173,14 +173,13 @@ class ATRCSurveyGroupCompleteIT {
         stagedRowRepo.saveAll(Arrays.asList(sn1b1, sn1b2, sn2b1, sn2b2, sn3b1, sn3b2, sn4b1));
 
         ValidationResponse response = validationProcess.process(job);
-        assertTrue(response.getErrors().stream()
-                .anyMatch(e -> e.getMessage().startsWith("Survey incomplete: ERZ1/11/09/2020/7.1 Missing M2, M3")));
-        assertTrue(response.getErrors().stream()
-                .anyMatch(e -> e.getMessage().startsWith("Survey incomplete: ERZ1/11/09/2020/7.2 Missing M2, M3")));
-        assertTrue(response.getErrors().stream()
-                .anyMatch(e -> e.getMessage().startsWith("Survey incomplete: ERZ1/11/09/2020/7.3 Missing M2, M3")));
-        assertTrue(response.getErrors().stream()
-                .anyMatch(e -> e.getMessage().startsWith("Survey incomplete: ERZ1/11/09/2020/7.4 Missing M2, M3")));
+        var errors = response.getErrors().stream().map(e -> e.getMessage()).filter(m -> m.contains("incomplete")).sorted().toArray();
+
+        assertTrue(errors.length == 4);
+        assertTrue(errors[0].equals("Survey incomplete: [ERZ1, 2020-09-11, 7.1] missing M2, M3"));
+        assertTrue(errors[1].equals("Survey incomplete: [ERZ1, 2020-09-11, 7.2] missing M2, M3"));
+        assertTrue(errors[2].equals("Survey incomplete: [ERZ1, 2020-09-11, 7.3] missing M2, M3"));
+        assertTrue(errors[3].equals("Survey incomplete: [ERZ1, 2020-09-11, 7.4] missing M2, M3. M1 missing B2"));
     }
 
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/RLSMethodBlockAssociationIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/RLSMethodBlockAssociationIT.java
@@ -93,7 +93,7 @@ class RLSMethodBlockAssociationIT {
 
         StagedJob job = jobRepo.findByReference("jobid-rls").get();
         String date = "11/09/2020";
-        String depth = "7";
+        String depth = "7.1";
         String siteNo = "ERZ1";
 
         StagedRow m1b1 = new StagedRow();
@@ -115,6 +115,6 @@ class RLSMethodBlockAssociationIT {
 
         ValidationResponse response = validationProcess.process(job);
         assertTrue(response.getErrors().stream()
-                .anyMatch(e -> e.getMessage().startsWith("Survey incomplete: ERZ1/11/09/2020/7 M2 missing B2")));
+                .anyMatch(e -> e.getMessage().startsWith("Survey incomplete: [ERZ1, 2020-09-11, 7.1] M2 missing B2")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/RLSMethodCheckIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/RLSMethodCheckIT.java
@@ -79,7 +79,7 @@ class RLSMethodCheckIT {
 
         ValidationResponse response = validationProcess.process(job);
         assertTrue(response.getErrors().stream()
-                .anyMatch(e -> e.getMessage().startsWith("Survey incomplete: ERZ1/11/09/2020/7")));
+                .anyMatch(e -> e.getMessage().contains("Survey incomplete")));
     }
 
     @Test
@@ -152,6 +152,6 @@ class RLSMethodCheckIT {
 
         ValidationResponse response = validationProcess.process(job);
         assertTrue(response.getErrors().stream()
-                .anyMatch(e -> e.getMessage().startsWith("Survey incomplete: ERZ1/11/09/2020/7 Missing M2")));
+                .anyMatch(e -> e.getMessage().contains("missing M2")));
     }
 }


### PR DESCRIPTION
Format the survey as "[site, date, depth.surveyNumber]" in the validation messages instead of just printing "site/date/depth".
This adds extra space to make it easier to read and also shows the survey number.