### PR TITLE
Improve display of version and feature flags in side menu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.\#*
+\#*
 
 settings.json
 

--- a/web/src/components/layout/SideMenu.js
+++ b/web/src/components/layout/SideMenu.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import {Box, Divider, Drawer, IconButton, List, ListSubheader, Typography, ListItem, ListItemText} from '@mui/material';
+import {Box, Divider, Drawer, IconButton, List, ListItem, ListItemText, ListSubheader, Stack, Typography} from '@mui/material';
+import Chip from '@mui/material/Chip';
 import MenuIcon from '@mui/icons-material/Menu';
 import {NavLink} from 'react-router-dom';
 import {PropTypes} from 'prop-types';
@@ -41,7 +42,7 @@ const SideMenu = ({open, onClose}) => {
           </ListItem>
         </List>
       </List>
-      <Divider />
+      <Divider/>
       <List>
         <ListSubheader>
           <Typography variant="button">Reference Data</Typography>
@@ -59,17 +60,15 @@ const SideMenu = ({open, onClose}) => {
           <ListItemText primary="Observable Items" />
         </ListItem>
       </List>
-      <List>
-        <Divider />
-        <ListSubheader>{`Version ${version[0]}.${version[1]} (${version[2]})`}</ListSubheader>
-      </List>
+      <Divider/>
       <AuthContext.Consumer>
         {({auth}) => (
-          <Box ml={2}>
+          <Stack direction="column" spacing={1} m={2}>
+            <Chip color="primary" size="small" label={`Version ${version[0]}.${version[1]} (${version[2]})`}/>
             {auth?.features?.map((label, i) => (
-              <small key={i}>{label}</small>
+              <Chip key={i} color="primary" variant="outlined" size="small" label={label}/>
             ))}
-          </Box>
+          </Stack>
         )}
       </AuthContext.Consumer>
     </Drawer>


### PR DESCRIPTION
Display version and features as a stack of Material UI chips instead of a a list of text labels.

Also add temporary files starting with `#` or `.#` to `.gitignore`.