### PR TITLE
Normalise date format before survey validation checks

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedRow.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedRow.java
@@ -2,6 +2,7 @@ package au.org.aodn.nrmn.restapi.model.db;
 
 import java.io.Serializable;
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.Map;
 
 import javax.persistence.Column;
@@ -24,6 +25,7 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.Type;
 import org.hibernate.annotations.TypeDef;
 import org.hibernate.annotations.UpdateTimestamp;
+import au.org.aodn.nrmn.restapi.util.TimeUtils;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -156,20 +158,29 @@ public class StagedRow implements Serializable {
     @Setter(AccessLevel.NONE)
     private Timestamp lastUpdated;
 
+    private String dateNormalised() {
+        try {
+            LocalDate d = LocalDate.parse(date, TimeUtils.getRowDateFormatter());
+            return d != null ? d.toString() : date;
+        } catch (Exception e) {
+            return date;
+        }
+    }
+
     public String getContentsHash(boolean includeTotal) {
         // String measurements = measureJson.entrySet().stream().map(m -> m.getValue().length() > 0 ? m.getKey().toString() + ":" + m.getValue() + "|" : "").reduce("", (a, b) -> a + b);
-        String rowContents = siteCode + date + diver + depth + method + block + species + buddy + siteName + longitude + latitude + vis + time + direction + pqs + code + commonName + inverts + isInvertSizing; // + total + measurements;
+        String rowContents = siteCode + dateNormalised() + diver + depth + method + block + species + buddy + siteName + longitude + latitude + vis + time + direction + pqs + code + commonName + inverts + isInvertSizing; // + total + measurements;
         if(includeTotal) rowContents += total;
         return Integer.toString(rowContents.hashCode());
     }
 
     public String getSurveyGroup() {
         String depthPart = depth.split("\\.")[0];
-        return (siteCode + "/" + date + "/" + depthPart).toUpperCase();
+        return (siteCode + "/" + dateNormalised() + "/" + depthPart).toUpperCase();
     }
 
     public String getSurvey() {
-        return (siteCode + "/" + date + "/" + depth).toUpperCase();
+        return (siteCode + "/" + dateNormalised() + "/" + depth).toUpperCase();
     }
 
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedRow.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/StagedRow.java
@@ -176,10 +176,6 @@ public class StagedRow implements Serializable {
 
     public String getSurveyGroup() {
         String depthPart = depth.split("\\.")[0];
-        return (siteCode + "/" + dateNormalised() + "/" + depthPart).toUpperCase();
-    }
-
-    public String getSurvey() {
         return String.format("[%s, %s, %s]", siteCode,  dateNormalised(), depthPart).toUpperCase();
     }
 

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ATRCSurveyGroupCompleteIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ATRCSurveyGroupCompleteIT.java
@@ -137,6 +137,56 @@ class ATRCSurveyGroupCompleteIT {
     }
 
     @Test
+    void groupWithDifferentDateFormatShouldSucceed() {
+        StagedJob job = jobRepo.findByReference("jobid-atrc").get();
+        String date1 = "11/09/2020";
+        String date2 = "11/09/20";
+
+        String siteNo = "ERZ1";
+
+        StagedRow sn1b1 = new StagedRow();
+        sn1b1.setDate(date1);
+        sn1b1.setDepth("7.1");
+        sn1b1.setMethod("1");
+        sn1b1.setBlock("1");
+        sn1b1.setSiteCode(siteNo);
+        sn1b1.setStagedJob(job);
+
+        StagedRow sn1b2 = (StagedRow) SerializationUtils.clone(sn1b1);
+        sn1b2.setDate(date1);
+        sn1b2.setBlock("2");
+
+        StagedRow sn2b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        sn2b1.setDate(date1);
+        sn2b1.setDepth("7.2");
+        StagedRow sn2b2 = (StagedRow) SerializationUtils.clone(sn2b1);
+        sn2b2.setDate(date2);
+        sn2b2.setBlock("2");
+
+        StagedRow sn3b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        sn3b1.setDate(date2);
+        sn3b1.setDepth("7.3");
+        StagedRow sn3b2 = (StagedRow) SerializationUtils.clone(sn3b1);
+        sn3b2.setDate(date2);
+        sn3b2.setBlock("2");
+
+        StagedRow sn4b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        sn4b1.setDate(date2);
+        sn4b1.setDepth("7.4");
+        StagedRow sn4b2 = (StagedRow) SerializationUtils.clone(sn4b1);
+        sn4b2.setBlock("2");
+
+        Location location = Location.builder().locationName("LOC1").isActive(false).build();
+        locationRepository.save(location);
+        siteRepository.save(Site.builder().siteName("ERZ1").siteCode("ERZ1").location(location).isActive(true).build());
+        stagedRowRepo.saveAll(Arrays.asList(sn1b1, sn1b2, sn2b1, sn2b2, sn3b1, sn3b2, sn4b1, sn4b2));
+
+        ValidationResponse response = validationProcess.process(job);
+        assertTrue(!response.getErrors().stream().anyMatch(e -> e.getMessage().startsWith("Survey group incomplete")));
+    }
+
+
+    @Test
     void groupWithIncompleteSurveyBlocksShouldFail() {
         StagedJob job = jobRepo.findByReference("jobid-atrc").get();
         String date = "11/09/2020";


### PR DESCRIPTION
Parse the row date and format consistently for the validations that use survey grouping.
Necessary since we are supporting multiple date formats.