### PR TITLE
Add table styles and apply to species search to improve readability

### DIFF
--- a/web/src/App.js
+++ b/web/src/App.js
@@ -50,10 +50,15 @@ const App = () => {
     () =>
       responsiveFontSizes(
         createTheme({
+          typography: {
+            table: {
+              fontSize: 11,
+              padding: 6
+          }},
           palette: {
             mode: 'light',
-            primary: {main: '#546E7B', light: '#AADFFA', dark: '546E7B'},
-            secondary: {main: '#563FF2', light: '#7D69FF', dark: '5844DB'}
+            primary: {main: '#546E7B', light: '#AADFFA', dark: '#546E7B', rowHeader: '#E4EAED', rowHighlight: '#F2F6F7'},
+            secondary: {main: '#563FF2', light: '#7D69FF', dark: '#5844DB',  rowHeader: '#E4EAED', rowHighlight: '#F2F6F7'}
           }
         })
       ),
@@ -64,10 +69,14 @@ const App = () => {
     () =>
       responsiveFontSizes(
         createTheme({
+          typography: {
+            table: {
+              fontSize: 11,
+          }},
           palette: {
             mode: 'light',
-            primary: {main: '#7B6154', light: '#AADFFA', dark: '546E7B'},
-            secondary: {main: '#563FF2', light: '#7D69FF', dark: '5844DB'}
+            primary: {main: '#7B6154', light: '#AADFFA', dark: '#546E7B', rowHeader: '#E4EAED', rowHighlight: '#F2F6F7'},
+            secondary: {main: '#563FF2', light: '#7D69FF', dark: '#5844DB', rowHeader: '#E4EAED', rowHighlight: '#F2F6F7'}
           }
         })
       ),

--- a/web/src/components/data-entities/location/LocationList.js
+++ b/web/src/components/data-entities/location/LocationList.js
@@ -88,9 +88,9 @@ const LocationList = () => {
           />
           <AgGridColumn field="locationName" sort="asc" cellStyle={{cursor: 'pointer'}} onCellClicked={(e) => setRedirect(e.data.id)} />
           <AgGridColumn maxWidth={80} field="status" />
-          <AgGridColumn cellStyle={{'min-width': '600px'}} field="ecoRegions" />
+          <AgGridColumn minWidth={600} field="ecoRegions" />
           <AgGridColumn field="countries" />
-          <AgGridColumn cellStyle={{'min-width': '600px'}} field="areas" />
+          <AgGridColumn minWidth={600} field="areas" />
         </AgGridReact>
       </Box>
     </>

--- a/web/src/components/data-entities/observable-item/ObservableItemList.js
+++ b/web/src/components/data-entities/observable-item/ObservableItemList.js
@@ -95,7 +95,7 @@ const ObservableItemList = () => {
           }}
         />
         <AgGridColumn field="typeName" headerName="Type" />
-        <AgGridColumn cellStyle={{'min-width': '200px'}} field="name" />
+        <AgGridColumn minWidth={200} field="name" />
         <AgGridColumn field="commonName" />
         <AgGridColumn field="supersededBy" />
         <AgGridColumn field="supersededNames" />

--- a/web/src/components/data-entities/site/SiteList.js
+++ b/web/src/components/data-entities/site/SiteList.js
@@ -127,10 +127,10 @@ const SiteList = () => {
               }
             }}
           />
-          <AgGridColumn cellStyle={{'min-width': '500px'}} field="siteName" />
-          <AgGridColumn cellStyle={{'min-width': '200px'}} field="locationName" />
+          <AgGridColumn minWidth={500} field="siteName" />
+          <AgGridColumn minWidth={200} field="locationName" />
           <AgGridColumn field="state" />
-          <AgGridColumn cellStyle={{'min-width': '200px'}} field="country" />
+          <AgGridColumn minWidth={200} field="country" />
           <AgGridColumn field="latitude" />
           <AgGridColumn field="longitude" />
           <AgGridColumn suppressMenu={true} field="isActive" headerName="Active" />

--- a/web/src/components/search/SpeciesSearch.js
+++ b/web/src/components/search/SpeciesSearch.js
@@ -1,5 +1,6 @@
 import React, {useEffect, useState} from 'react';
 import {Box, Divider, Paper, Grid, Tab, Tabs, TextField, Typography} from '@mui/material';
+import {makeStyles} from '@mui/styles';
 import Table from '@mui/material/Table';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
@@ -14,7 +15,34 @@ import {search} from '../../api/api';
 import PropTypes from 'prop-types';
 import LoadingButton from '@mui/lab/LoadingButton';
 
+const useStyles = makeStyles(({ palette, typography }) => ({
+  root: {
+    '& .MuiTable-root': {
+      '& .MuiTableHead-root': {
+        '& .MuiTableRow-head': {
+          '& .MuiTableCell-head': {
+            fontSize: typography.table.fontSize,
+            background: palette.primary.rowHeader
+          },
+        },
+      },
+      '& .MuiTableRow-root': {
+        '&:nth-child(even)': {
+          backgroundColor: palette.primary.rowHighlight,
+        },
+      },
+      '& .MuiTableCell-root': {
+        fontSize: typography.table.fontSize,
+        padding: typography.table.padding,
+        color: palette.text.textPrimary,
+      },
+    },
+  },
+}));
+
 const SpeciesSearch = ({onRowClick}) => {
+  const classes = useStyles();
+
   const [tabIndex, setTabIndex] = useState(0);
   const [searchTerm, setSearchTerm] = useState();
   const [page, setPage] = useState(0);
@@ -172,8 +200,8 @@ const SpeciesSearch = ({onRowClick}) => {
       </TabPanel>
       {gridData ? (
         <>
-          <TableContainer component={Paper}>
-            <Table size="small">
+          <TableContainer classes={classes} component={Paper}>
+            <Table>
               <TableHead>
                 <TableRow>
                   <TableCell>Is Present</TableCell>


### PR DESCRIPTION
Add styles to the global theme and applies them to the Species Search table.
Also fixes console warning due to use of `min-width`. Replaces with the AgGrid column prop `minWidth`.