### PR TITLE
Add Unicode byte order mark to template export diver CSV

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/TemplateService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/TemplateService.java
@@ -62,9 +62,10 @@ public class TemplateService {
     public void writeZip(OutputStream outputStream, Collection<Integer> locations) throws IOException {
 
         ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream);
-        Writer writer = new OutputStreamWriter(zipOutputStream, "UTF-8");
+        Writer writer = new OutputStreamWriter(zipOutputStream, StandardCharsets.UTF_8);
 
         zipOutputStream.putNextEntry(new ZipEntry("divers.csv"));
+        writer.write('\ufeff');
         writeDiversCsv(writer, getDiversForTemplate());
         writer.flush();
         zipOutputStream.closeEntry();


### PR DESCRIPTION
Some versions of Excel apparently require this regardless of encoding. See: https://stackoverflow.com/questions/155097/microsoft-excel-mangles-diacritics-in-csv-files