### PR TITLE
Reduce grid edit cell height

### DIFF
--- a/web/src/components/import/panel/ValidationPanel.js
+++ b/web/src/components/import/panel/ValidationPanel.js
@@ -64,13 +64,13 @@ const ValidationPanel = (props) => {
             </TableRow>
             <TableRow>
               <TableCell>{summary.siteCount}</TableCell>
-              <Tooltip title={siteTooltip} interactive>
+              <Tooltip title={siteTooltip}>
                 <TableCell>distinct sites found</TableCell>
               </Tooltip>
             </TableRow>
             <TableRow>
               <TableCell></TableCell>
-              <Tooltip title={newSitesTooltip} interactive>
+              <Tooltip title={newSitesTooltip}>
                 <TableCell>{summary.newSiteCount} new sites found</TableCell>
               </Tooltip>
             </TableRow>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -3,6 +3,10 @@
   line-height: 20px;
 }
 
+.ag-theme-material .ag-cell-inline-editing {
+  height: 36px;
+}
+
 #validation-grid  .ag-cell[role="gridcell"] {
   border-right: 1px solid #ccc;
 }
@@ -37,3 +41,5 @@
   margin-right: 25px;
   border-left: 2px solid #ccc;
 }
+
+


### PR DESCRIPTION
Fix the edit cell from being clipped by the filter row when there are only two rows in the grid. 
Also remove some obsolete props that were causing runtime warnings.