### PR TITLE
Fix Species Search pagination

### DIFF
--- a/web/src/components/search/SpeciesSearch.js
+++ b/web/src/components/search/SpeciesSearch.js
@@ -112,7 +112,7 @@ const SpeciesSearch = ({onRowClick}) => {
             setGridData(gridData ? [...gridData, ...data] : data);
             setPage(searchRequested.page);
             if(data?.length < rowsPerPage)
-              setMaxRows(data.length);
+              setMaxRows(gridData.length + data.length);
           }
         })
         .catch((err) => setSearchError(err.message));
@@ -121,7 +121,7 @@ const SpeciesSearch = ({onRowClick}) => {
   }, [searchRequested, currentSearch, rowsPerPage, gridData]);
 
   const handleChangePage = (_, newPage) => {
-    if(page < newPage && gridData.length / rowsPerPage < newPage + 1)
+    if(maxRows < 0 && page < newPage)
       setSearchRequested({searchType: tabIndex === 0 ? 'WORMS' : 'NRMN', species: searchTerm, includeSuperseded: true, page: newPage});
     else
       setPage(newPage);

--- a/web/src/components/search/__test__/SpeciesSearch.test.tsx
+++ b/web/src/components/search/__test__/SpeciesSearch.test.tsx
@@ -3,6 +3,7 @@ import '@testing-library/jest-dom';
 import {fireEvent, render, waitFor} from '@testing-library/react';
 import {rest} from 'msw';
 import {setupServer} from 'msw/node';
+import { exact } from 'prop-types';
 import React from 'react';
 import SpeciesSearch from '../SpeciesSearch';
 
@@ -10,7 +11,7 @@ const visibleProps = ['class', 'family', 'genus', 'order', 'phylum', 'species', 
 const props = [...visibleProps, 'supersededBy', 'unacceptReason', 'aphiaId'];
 
 const pages = Array.from({length: 3}, (_, i) => i).map((p) =>
-  Array.from({length: 50}, (_, i) => i).map((i) => {
+  Array.from({length: p == 2 ? 25 : 50}, (_, i) => i).map((i) => {
     return props.reduce((row, prop) => {
       row[prop] = `${prop}.${p}.${i}`;
       return row;
@@ -64,9 +65,10 @@ describe('<SiteList/>', () => {
         expect(queryByText(`${prop}.${page}.0`)).toBeInTheDocument();
         expect(queryByText(`${prop}.${page + 1}.0`)).not.toBeInTheDocument();
         if (page > 0) expect(queryByText(`${prop}.${page - 1}.0`)).not.toBeInTheDocument();
-        expect(queryByText(`${prop}.${page}.49`)).toBeInTheDocument();
-        expect(queryByText(`${prop}.${page}.50`)).not.toBeInTheDocument();
+        expect(queryByText(`${prop}.${page}.${pages[page].length-1}`)).toBeInTheDocument();
+        expect(queryByText(`${prop}.${page}.${pages[page].length}`)).not.toBeInTheDocument();
       }
+      expect(queryByText(`${page*50 + 1}–${page*50 + pages[page].length} of`, {exact: false})).toBeInTheDocument();
     };
 
     await waitFor(() => expectedPage(0));


### PR DESCRIPTION
- Fix bug causing pagination to break when last page is less than maxPage size
- Update test to check the count in the footer (eg `1-50`) are correct