### PR TITLE
Improve SiteList Test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,7 +33,6 @@
       "request": "launch",
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen",
-      "disableOptimisticBPs": true,
       "cwd": "${workspaceFolder}/web",
       "runtimeExecutable": "yarn",
       "args": ["-s", "test", "--runInBand", "--watchAll=false"]

--- a/web/src/components/data-entities/site/__test__/SiteList.test.tsx
+++ b/web/src/components/data-entities/site/__test__/SiteList.test.tsx
@@ -31,11 +31,9 @@ describe('<SiteList/>', () => {
   test('Renders ' + visibleColumns.join(','), async () => {
     const history = createMemoryHistory();
     const {getByText} = render(<Router location={history.location} navigator={history}><SiteList /></Router>);
-    await waitFor(() => {
-      for(const row of siteTestData) 
-      for(const field of visibleColumns)
-        expect(getByText(`${row[field]}`));
-    });
+    for(const row of siteTestData) 
+    for(const field of visibleColumns)
+      await waitFor(() => expect(getByText(`${row[field]}`)));
   });
 
   test('Clone Icon appears for every site', async () => {

--- a/web/src/components/import/__test__/DataSheetView.test.tsx
+++ b/web/src/components/import/__test__/DataSheetView.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { render, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import {describe, beforeAll, afterEach, jest} from "@jest/globals";

--- a/web/src/components/search/__test__/SpeciesSearch.test.tsx
+++ b/web/src/components/search/__test__/SpeciesSearch.test.tsx
@@ -3,8 +3,6 @@ import '@testing-library/jest-dom';
 import {fireEvent, render, waitFor} from '@testing-library/react';
 import {rest} from 'msw';
 import {setupServer} from 'msw/node';
-import { exact } from 'prop-types';
-import React from 'react';
 import SpeciesSearch from '../SpeciesSearch';
 
 const visibleProps = ['class', 'family', 'genus', 'order', 'phylum', 'species', 'status'];

--- a/web/src/components/ui/__test__/AlertDialog.test.tsx
+++ b/web/src/components/ui/__test__/AlertDialog.test.tsx
@@ -1,5 +1,3 @@
-// @ts-ignore
-import React from 'react';
 import AlertDialog from '../AlertDialog';
 import { render, fireEvent } from '@testing-library/react';
 import { describe, it, test, expect } from '@jest/globals';


### PR DESCRIPTION
Looping on the expect within await appears to sometimes fail. Fix so the await is in the innermost loop.

Also remove some unused imports and unneeded annotations.