### PR TITLE
Fix potential ReDoS in WoRMS search regex

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/WormsService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/WormsService.java
@@ -21,7 +21,7 @@ import java.util.stream.Collectors;
 @Service
 public class WormsService {
 
-    static private Pattern REMOVE_TRAILING_JUNK_PATTERN = Pattern.compile("( (sp\\.|spp\\.))?( (\\(.*\\)|\\[.*\\]))?$",
+    static private Pattern REMOVE_TRAILING_JUNK_PATTERN = Pattern.compile("(( (sp\\.|spp\\.).+)|( \\(.+)|( \\[.+))",
             Pattern.CASE_INSENSITIVE);
 
     private final WebClient wormsClient;


### PR DESCRIPTION
Split `(` and `[` checks into different capturing groups.