### PR TITLE
Add missing integer mappings for Block and Total columns

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
@@ -44,7 +44,7 @@ public class StagedRowFormattedMapperConfig {
 
         Converter<Long, StagedRow> toRef = ctx -> rowMap.get(ctx.getSource());
 
-        Converter<String, Optional<UiSpeciesAttributes>> toSpeciesAttributesOpt = ctx -> {
+        Converter<String, Optional<UiSpeciesAttributes>> toSpeciesAttribute = ctx -> {
             UiSpeciesAttributes speciesAttributes = speciesAttributesMap.get(ctx.getSource());
             return speciesAttributes != null ? Optional.of(speciesAttributes) : Optional.empty();
         };
@@ -131,23 +131,28 @@ public class StagedRowFormattedMapperConfig {
 
         ModelMapper modelMapper = new ModelMapper();
         modelMapper.typeMap(StagedRow.class, StagedRowFormatted.class).addMappings(mapper -> {
-            mapper.using(toObservableItem).map(StagedRow::getSpecies, StagedRowFormatted::setSpecies);
-            mapper.using(toSpeciesAttributesOpt).map(StagedRow::getSpecies,
-                    StagedRowFormatted::setSpeciesAttributesOpt);
-            mapper.using(toMeasureJson).map(StagedRow::getMeasureJson, StagedRowFormatted::setMeasureJson);
+
             mapper.using(toDiver).map(StagedRow::getDiver, StagedRowFormatted::setDiver);
-            mapper.using(toDirection).map(StagedRow::getDirection, StagedRowFormatted::setDirection);
             mapper.using(toDiver).map(StagedRow::getPqs, StagedRowFormatted::setPqs);
+
             mapper.using(toDouble).map(StagedRow::getLatitude, StagedRowFormatted::setLatitude);
             mapper.using(toDouble).map(StagedRow::getLongitude, StagedRowFormatted::setLongitude);
-            mapper.using(toRef).map(StagedRow::getId, StagedRowFormatted::setRef);
-            mapper.using(toSite).map(StagedRow::getSiteCode, StagedRowFormatted::setSite);
+
+            mapper.using(toInteger).map(StagedRow::getBlock, StagedRowFormatted::setBlock);
+            mapper.using(toInteger).map(StagedRow::getInverts, StagedRowFormatted::setInverts);
+            mapper.using(toInteger).map(StagedRow::getMethod, StagedRowFormatted::setMethod);
+            mapper.using(toInteger).map(StagedRow::getTotal, StagedRowFormatted::setTotal);
+
             mapper.using(toDate).map(StagedRow::getDate, StagedRowFormatted::setDate);
             mapper.using(toDepth).map(StagedRow::getDepth, StagedRowFormatted::setDepth);
-            mapper.using(toInteger).map(StagedRow::getMethod, StagedRowFormatted::setMethod);
-            mapper.using(toInteger).map(StagedRow::getInverts, StagedRowFormatted::setInverts);
-            mapper.using(toSurveyNum).map(StagedRow::getDepth, StagedRowFormatted::setSurveyNum);
+            mapper.using(toDirection).map(StagedRow::getDirection, StagedRowFormatted::setDirection);
             mapper.using(toInvertSizing).map(StagedRow::getIsInvertSizing, StagedRowFormatted::setIsInvertSizing);
+            mapper.using(toMeasureJson).map(StagedRow::getMeasureJson, StagedRowFormatted::setMeasureJson);
+            mapper.using(toObservableItem).map(StagedRow::getSpecies, StagedRowFormatted::setSpecies);
+            mapper.using(toRef).map(StagedRow::getId, StagedRowFormatted::setRef);
+            mapper.using(toSite).map(StagedRow::getSiteCode, StagedRowFormatted::setSite);
+            mapper.using(toSpeciesAttribute).map(StagedRow::getSpecies, StagedRowFormatted::setSpeciesAttributesOpt);
+            mapper.using(toSurveyNum).map(StagedRow::getDepth, StagedRowFormatted::setSurveyNum);
             mapper.using(toTime).map(StagedRow::getTime, StagedRowFormatted::setTime);
             mapper.using(toVis).map(StagedRow::getVis, StagedRowFormatted::setVis);
         });

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
@@ -100,7 +100,7 @@ public class StagedRowFormattedMapperConfig {
 
         Converter<String, Double> toDouble = ctx -> {
             Double dbl = NumberUtils.toDouble(ctx.getSource(), Double.NaN);
-            return (dbl != Double.NaN) ? dbl : null;
+            return Double.isNaN(dbl) ? null : dbl;
         };
 
         Converter<String, Integer> toInteger = ctx -> {

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/StagedRowFormattedMappingIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/StagedRowFormattedMappingIT.java
@@ -1,5 +1,7 @@
 package au.org.aodn.nrmn.restapi.validation.process;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.time.LocalDate;
@@ -98,5 +100,69 @@ class StagedRowFormattedMappingIT {
         assertEquals(Optional.of(10.0), formattedRow.getVis());
         assertEquals(4, formattedRow.getSurveyNum());
         assertEquals(7, formattedRow.getDepth());
+    }
+
+    @Test
+    void invalidMappingsShouldBeNull() {
+
+        StagedJob job = new StagedJob();
+        job.setId(1L);
+        job.setIsExtendedSize(false);
+        Program program = new Program();
+        program.setProgramId(1);
+        program.setProgramName("RLS");
+        job.setProgram(program);
+
+        StagedRow row = new StagedRow();
+        row.setStagedJob(job);
+        row.setBlock("1]");
+        row.setCode("]]]]]");
+        row.setDate("The Past");
+        row.setDepth("Very Deep");
+        row.setDirection("Directly under the earth's sun");
+        row.setDiver("");
+        row.setInverts("0]");
+        row.setLatitude("BBB");
+        row.setLongitude("AAA");
+        row.setMethod("]]]]]]");
+        row.setPqs("Nonexistent PQ diver");
+        row.setSiteCode("");
+        row.setSpecies("Nonexistent Species");
+        row.setTime("Eleven:Thirty");
+        row.setTotal("]]]]]]");
+        row.setVis("Very Murky");
+        row.setMeasureJson(new HashMap<Integer, String>() {
+            {
+                put(13, "1]");
+            }
+        });
+
+        Collection<ObservableItem> species = observableItemRepository
+                .getAllSpeciesNamesMatching(Arrays.asList(row.getSpecies()));
+
+        Collection<StagedRowFormatted> validatedRows = validationProcess
+                .formatRowsWithSpecies(Arrays.asList(row), species);
+
+        assertEquals(1, validatedRows.size());
+
+        StagedRowFormatted formattedRow = (StagedRowFormatted) validatedRows.toArray()[0];
+
+        assertNull(formattedRow.getBlock());
+        assertNull(formattedRow.getDate());
+        assertNull(formattedRow.getDepth());
+        assertNull(formattedRow.getDirection());
+        assertNull(formattedRow.getDiver());
+        assertNull(formattedRow.getInverts());
+        assertNull(formattedRow.getLatitude());
+        assertNull(formattedRow.getLongitude());
+        assertNull(formattedRow.getMethod());
+        assertNull(formattedRow.getPqs());
+        assertNull(formattedRow.getSite());
+        assertNull(formattedRow.getTotal());
+        assertNull(formattedRow.getMeasureJson().get(13));
+
+        assertFalse(formattedRow.getSpecies().isPresent());
+        assertFalse(formattedRow.getTime().isPresent());
+        assertFalse(formattedRow.getVis().isPresent());
     }
 }


### PR DESCRIPTION
Block and Total values are using the default modelmapper mapping resulting in an unhandled exception when either value is not a number.

Fix found another bug where the Latitude and Longitude values were being returned as NaN instead of null if the conversion failed.

Add an invalid mappings test.