### PR TITLE
Speed up Survey and Site list queries

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SurveyController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SurveyController.java
@@ -1,10 +1,12 @@
 package au.org.aodn.nrmn.restapi.controller;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 
+import org.apache.commons.lang3.StringUtils;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -23,6 +25,7 @@ import au.org.aodn.nrmn.restapi.model.db.Survey;
 import au.org.aodn.nrmn.restapi.repository.ProgramRepository;
 import au.org.aodn.nrmn.restapi.repository.SurveyRepository;
 import au.org.aodn.nrmn.restapi.repository.projections.SurveyRowCacheable;
+import au.org.aodn.nrmn.restapi.repository.projections.SurveyRowDivers;
 import au.org.aodn.nrmn.restapi.service.SurveyEditService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -46,10 +49,22 @@ public class SurveyController {
     @GetMapping(path = "/surveys")
     public ResponseEntity<List<SurveyRowCacheable>> listMatching(SurveyFilterDto surveyFilter) {
         // if (surveyFilter.isSet())
-        //     return ResponseEntity
-        //             .ok(surveyRepository.findByCriteria(surveyFilter).stream().collect(Collectors.toList()));
+        // return ResponseEntity
+        // .ok(surveyRepository.findByCriteria(surveyFilter).stream().collect(Collectors.toList()));
         // else
-            return ResponseEntity.ok(surveyRepository.findAllProjectedBy().stream().collect(Collectors.toList()));
+        // return ResponseEntity.ok();
+        // getDiversFromSurveys
+        var surveyRows = surveyRepository.findAllProjectedBy().stream().collect(Collectors.toList());
+        var surveyIds = surveyRows.stream().map(s -> s.getSurveyId()).collect(Collectors.toList());
+        Map<Integer, String> diverNames = surveyRepository.getDiversForSurvey(surveyIds).stream()
+                .collect(Collectors.groupingBy(SurveyRowDivers::getSurveyId, Collectors.mapping(SurveyRowDivers::getDiverName, Collectors.joining(", "))));
+
+        var surveyRowsWithDivers = surveyRows.stream().map(s -> {
+            s.setDiverNames(diverNames.get(s.getSurveyId()));
+            return s;
+        }).collect(Collectors.toList());
+        
+        return ResponseEntity.ok(surveyRowsWithDivers);
     }
 
     @GetMapping(path = "/programs")

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SurveyController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SurveyController.java
@@ -6,7 +6,6 @@ import java.util.stream.Collectors;
 
 import javax.validation.Valid;
 
-import org.apache.commons.lang3.StringUtils;
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +23,6 @@ import au.org.aodn.nrmn.restapi.model.db.Program;
 import au.org.aodn.nrmn.restapi.model.db.Survey;
 import au.org.aodn.nrmn.restapi.repository.ProgramRepository;
 import au.org.aodn.nrmn.restapi.repository.SurveyRepository;
-import au.org.aodn.nrmn.restapi.repository.projections.SurveyRowCacheable;
 import au.org.aodn.nrmn.restapi.repository.projections.SurveyRowDivers;
 import au.org.aodn.nrmn.restapi.service.SurveyEditService;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -47,24 +45,25 @@ public class SurveyController {
     private ModelMapper mapper;
 
     @GetMapping(path = "/surveys")
-    public ResponseEntity<List<SurveyRowCacheable>> listMatching(SurveyFilterDto surveyFilter) {
-        // if (surveyFilter.isSet())
-        // return ResponseEntity
-        // .ok(surveyRepository.findByCriteria(surveyFilter).stream().collect(Collectors.toList()));
-        // else
-        // return ResponseEntity.ok();
-        // getDiversFromSurveys
-        var surveyRows = surveyRepository.findAllProjectedBy().stream().collect(Collectors.toList());
-        var surveyIds = surveyRows.stream().map(s -> s.getSurveyId()).collect(Collectors.toList());
-        Map<Integer, String> diverNames = surveyRepository.getDiversForSurvey(surveyIds).stream()
-                .collect(Collectors.groupingBy(SurveyRowDivers::getSurveyId, Collectors.mapping(SurveyRowDivers::getDiverName, Collectors.joining(", "))));
+    public ResponseEntity<?> listMatching(SurveyFilterDto surveyFilter) {
+        if (surveyFilter.isSet()) {
+            return ResponseEntity
+                    .ok(surveyRepository.findByCriteria(surveyFilter).stream().collect(Collectors.toList()));
+        } else {
 
-        var surveyRowsWithDivers = surveyRows.stream().map(s -> {
-            s.setDiverNames(diverNames.get(s.getSurveyId()));
-            return s;
-        }).collect(Collectors.toList());
-        
-        return ResponseEntity.ok(surveyRowsWithDivers);
+            var surveyRows = surveyRepository.findAllProjectedBy().stream().collect(Collectors.toList());
+            var surveyIds = surveyRows.stream().map(s -> s.getSurveyId()).collect(Collectors.toList());
+            Map<Integer, String> diverNames = surveyRepository.getDiversForSurvey(surveyIds).stream()
+                    .collect(Collectors.groupingBy(SurveyRowDivers::getSurveyId,
+                            Collectors.mapping(SurveyRowDivers::getDiverName, Collectors.joining(", "))));
+
+            var surveyRowsWithDivers = surveyRows.stream().map(s -> {
+                s.setDiverNames(diverNames.get(s.getSurveyId()));
+                return s;
+            }).collect(Collectors.toList());
+
+            return ResponseEntity.ok(surveyRowsWithDivers);
+        }
     }
 
     @GetMapping(path = "/programs")

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SurveyController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SurveyController.java
@@ -22,7 +22,7 @@ import au.org.aodn.nrmn.restapi.model.db.Program;
 import au.org.aodn.nrmn.restapi.model.db.Survey;
 import au.org.aodn.nrmn.restapi.repository.ProgramRepository;
 import au.org.aodn.nrmn.restapi.repository.SurveyRepository;
-import au.org.aodn.nrmn.restapi.repository.projections.SurveyRow;
+import au.org.aodn.nrmn.restapi.repository.projections.SurveyRowCacheable;
 import au.org.aodn.nrmn.restapi.service.SurveyEditService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -44,11 +44,11 @@ public class SurveyController {
     private ModelMapper mapper;
 
     @GetMapping(path = "/surveys")
-    public ResponseEntity<List<SurveyRow>> listMatching(SurveyFilterDto surveyFilter) {
-        if (surveyFilter.isSet())
-            return ResponseEntity
-                    .ok(surveyRepository.findByCriteria(surveyFilter).stream().collect(Collectors.toList()));
-        else
+    public ResponseEntity<List<SurveyRowCacheable>> listMatching(SurveyFilterDto surveyFilter) {
+        // if (surveyFilter.isSet())
+        //     return ResponseEntity
+        //             .ok(surveyRepository.findByCriteria(surveyFilter).stream().collect(Collectors.toList()));
+        // else
             return ResponseEntity.ok(surveyRepository.findAllProjectedBy().stream().collect(Collectors.toList()));
     }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/ObservationRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/ObservationRepository.java
@@ -36,5 +36,4 @@ public interface ObservationRepository
             "as commonName, is_invert_sized as isInvertSized, l5, l95, maxabundance as maxAbundance, lmax " +
             "FROM  nrmn.ui_species_attributes   where observable_item_id in :id")
     List<UiSpeciesAttributes> getSpeciesAttributesByIds(@Param("id") Collection<Integer> id);
-
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SiteRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SiteRepository.java
@@ -46,6 +46,7 @@ public interface SiteRepository
     List<String> findAllSiteCodes();
 
     @Query(value = "SELECT * FROM {h-schema}site_ref WHERE site_code IS NOT NULL ORDER BY SUBSTRING(site_code, '^[A-Z]+'), CAST(SUBSTRING(site_code, '[0-9]+$') AS INTEGER)", nativeQuery = true)
+    @QueryHints({ @QueryHint(name = HINT_CACHEABLE, value = "true") })
     List<Site> findAll();
 
     @Query(value = "SELECT DISTINCT state FROM Site WHERE state is not null ORDER BY state")

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SurveyRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SurveyRepository.java
@@ -5,6 +5,7 @@ import au.org.aodn.nrmn.restapi.model.db.Site;
 import au.org.aodn.nrmn.restapi.model.db.Survey;
 import au.org.aodn.nrmn.restapi.repository.projections.SurveyRow;
 import au.org.aodn.nrmn.restapi.repository.projections.SurveyRowCacheable;
+import au.org.aodn.nrmn.restapi.repository.projections.SurveyRowDivers;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -29,18 +30,13 @@ public interface SurveyRepository extends JpaRepository<Survey, Integer>, JpaSpe
                 "    sv.depth, " +
                 "    sv.surveyNum, " +
                 "    sv.pqCatalogued, " +
-                "    st.siteName, " +
-                "    st.siteCode, " +
-                "    st.mpa, " +
-                "    st.country, " +
-                "    pg.programName, " +
-                "    lc.locationName " +
-                ") " +
-                "FROM Survey as sv " +
-                "LEFT JOIN sv.site as st " +
-                "LEFT JOIN sv.program as pg " +
-                "LEFT JOIN st.location as lc " +
-                "ORDER BY sv.surveyId DESC")
+                "    sv.site.siteName, " +
+                "    sv.site.siteCode, " +
+                "    sv.site.mpa, " +
+                "    sv.site.country, " +
+                "    sv.program.programName, " +
+                "    sv.site.location.locationName " +
+                ") FROM Survey as sv ORDER BY sv.surveyId DESC")
         List<SurveyRowCacheable> findAllProjectedBy();
 
         @Query("SELECT t FROM #{#entityName} t WHERE t.id IN :ids")
@@ -82,4 +78,8 @@ public interface SurveyRepository extends JpaRepository<Survey, Integer>, JpaSpe
 
         @Query("SELECT s FROM Survey s WHERE s.surveyId IN :ids AND (s.pqCatalogued = FALSE OR s.pqCatalogued IS NULL)")
         List<Survey> findSurveysWithoutPQ(@Param("ids") List<Integer> ids);
+
+        @QueryHints({ @QueryHint(name = HINT_CACHEABLE, value = "true") })
+        @Query("SELECT DISTINCT new au.org.aodn.nrmn.restapi.repository.projections.SurveyRowDivers(o.surveyMethod.survey.surveyId, o.diver.fullName) from Observation o where o.surveyMethod.survey.surveyId IN (:surveyIds)")
+        List<SurveyRowDivers> getDiversForSurvey(@Param("surveyIds") List<Integer> surveyIds);
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SurveyRow.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SurveyRow.java
@@ -1,5 +1,11 @@
 package au.org.aodn.nrmn.restapi.repository.projections;
 
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
+
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
 public interface SurveyRow {
     Integer getSurveyId();
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SurveyRowCacheable.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SurveyRowCacheable.java
@@ -6,11 +6,11 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.springframework.cache.annotation.Cacheable;
 
-import lombok.Value;
+import lombok.Getter;
 
 @Cacheable
 @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
-@Value
+@Getter
 public class SurveyRowCacheable {
     private Integer surveyId;
     private String siteName;
@@ -23,6 +23,11 @@ public class SurveyRowCacheable {
     private String country;
     private String programName;
     private String locationName;
+    private String diverName;
+
+    public void setDiverNames(String diverNames) {
+        this.diverName = diverNames;
+    }
 
     public SurveyRowCacheable(Integer surveyId, Date surveyDate, Date surveyTime, Integer depth, Integer surveyNum, Boolean hasPQs, String siteName, String siteCode, String mpa, String country, String programName, String locationName) {
         this.surveyId = surveyId;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SurveyRowCacheable.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SurveyRowCacheable.java
@@ -1,0 +1,40 @@
+package au.org.aodn.nrmn.restapi.repository.projections;
+
+import java.util.Date;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
+
+import lombok.Value;
+
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
+@Value
+public class SurveyRowCacheable {
+    private Integer surveyId;
+    private String siteName;
+    private Date surveyDate;
+    private Date surveyTime;
+    private String depth;
+    private String siteCode;
+    private String hasPQs;
+    private String mpa;
+    private String country;
+    private String programName;
+    private String locationName;
+
+    public SurveyRowCacheable(Integer surveyId, Date surveyDate, Date surveyTime, Integer depth, Integer surveyNum, Boolean hasPQs, String siteName, String siteCode, String mpa, String country, String programName, String locationName) {
+        this.surveyId = surveyId;
+        this.siteName = siteName;
+        this.surveyDate = surveyDate;
+        this.surveyTime = surveyTime;
+        this.depth = depth.toString() + "." + surveyNum.toString();
+        this.siteCode = siteCode;
+        this.hasPQs = hasPQs != null ? "true" : "false";
+        this.mpa = mpa;
+        this.country = country;
+        this.programName = programName;
+        this.locationName = locationName;
+    }
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SurveyRowDivers.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/projections/SurveyRowDivers.java
@@ -1,0 +1,20 @@
+package au.org.aodn.nrmn.restapi.repository.projections;
+
+import org.hibernate.annotations.Cache;
+import org.hibernate.annotations.CacheConcurrencyStrategy;
+import org.springframework.cache.annotation.Cacheable;
+
+import lombok.Value;
+
+@Cacheable
+@Cache(usage = CacheConcurrencyStrategy.READ_ONLY)
+@Value
+public class SurveyRowDivers {
+    private Integer surveyId;
+    private String diverName;
+
+    public SurveyRowDivers(Integer surveyId, String diverName) {
+        this.surveyId = surveyId;
+        this.diverName = diverName;
+    }
+}


### PR DESCRIPTION
- Rewrite the Survey List native query as two cacheable HQL queries.
- Add missing Cacheable annotation to the Site `getAll` method.

Survey List query should now complete in about a second, down from ~10 seconds.