### PR TITLE
Implement rate-limiting on auth endpoint methods

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -134,6 +134,12 @@
       <version>1.18.2</version>
       <scope>compile</scope>
     </dependency>
+    <!-- https://mvnrepository.com/artifact/com.github.vladimir-bukhtoyarov/bucket4j-core -->
+    <dependency>
+      <groupId>com.github.vladimir-bukhtoyarov</groupId>
+      <artifactId>bucket4j-core</artifactId>
+      <version>7.6.0</version>
+    </dependency>
     <!-- For Working with Json Web Tokens (JWT) see: https://github.com/jwtk-->
     <dependency>
       <groupId>io.jsonwebtoken</groupId>

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/config/RateLimitInterceptor.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/config/RateLimitInterceptor.java
@@ -1,0 +1,45 @@
+package au.org.aodn.nrmn.restapi.config;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import io.github.bucket4j.Bandwidth;
+import io.github.bucket4j.Bucket;
+import io.github.bucket4j.Refill;
+
+@Component
+public class RateLimitInterceptor implements HandlerInterceptor {
+
+    private final Map<String, Bucket> cache = new ConcurrentHashMap<>();
+
+    private Bucket newBucket(String apiKey) {
+        return Bucket.builder()
+                .addLimit(Bandwidth.classic(20, Refill.intervally(20, Duration.ofMinutes(10))))
+                .build();
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler)
+            throws Exception {
+        var details = (WebAuthenticationDetails) SecurityContextHolder.getContext().getAuthentication().getDetails();
+        var ipAddress = ((WebAuthenticationDetails) details).getRemoteAddress();
+        var bucket = cache.computeIfAbsent(ipAddress, this::newBucket);
+        var probe = bucket.tryConsumeAndReturnRemaining(1);
+        if (probe.isConsumed())
+            return true;
+        var seconds = probe.getNanosToWaitForRefill() / 1_000_000_000;
+        response.addHeader("X-Rate-Limit-Retry-After-Seconds", String.valueOf(seconds));
+        response.sendError(HttpStatus.TOO_MANY_REQUESTS.value(), String.valueOf(seconds));
+        return false;
+    }
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/config/WebMvcConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/config/WebMvcConfig.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -22,12 +23,17 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000", "https://*.aodn.org.au","http://*.dev.aodn.org.au")
                 .allowedMethods("HEAD", "OPTIONS", "GET", "POST", "PUT", "DELETE")
+                .exposedHeaders("X-Rate-Limit-Retry-After-Seconds")
                 .maxAge(MAX_AGE_SECS);
     }
 
     @Override
     public void addViewControllers(ViewControllerRegistry registry) {
-        frontendPagesWhitelist.stream()
-                .forEach(frontEndPage -> registry.addViewController(frontEndPage).setViewName("forward:/"));
+        frontendPagesWhitelist.stream().forEach(frontEndPage -> registry.addViewController(frontEndPage).setViewName("forward:/"));
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new RateLimitInterceptor()).addPathPatterns("/api/v1/auth/**");
     }
 }

--- a/web/src/api/api.js
+++ b/web/src/api/api.js
@@ -64,7 +64,14 @@ export const userLogin = (params, onResult) => {
         LicenseManager.setLicenseKey(res.data.gridLicense);
         onResult(state, null);
       } else {
-        onResult({expires: 0}, res.data.error);
+        const retryHeader = res.headers['x-rate-limit-retry-after-seconds'];
+        if (retryHeader) {
+          const seconds = parseInt(retryHeader);
+          const delay = seconds < 60 ? `${seconds} seconds.` : `${Math.ceil(seconds / 60)} minutes.`;
+          onResult({expires: 0}, `Too many authentication requests from your IP. Try again in ${delay}`);
+        } else {
+          onResult({expires: 0}, res.data.error);
+        }
       }
     });
 };


### PR DESCRIPTION
- Implements rate-limiting using bucket4j.
- Allow 20 auth requests every 10 minutes per IP address.
- When limit is reached display how long to wait until next attempt.