### PR TITLE
Rename correction job status from CORRECTION to CORRECTED

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -340,7 +340,7 @@ public class CorrectionController {
         var job = StagedJob.builder()
                 .source(SourceJobType.CORRECTION)
                 .reference("Correct Survey " + surveyName)
-                .status(StatusJobType.CORRECTION)
+                .status(StatusJobType.CORRECTED)
                 .program(survey.getProgram())
                 .creator(user.get())
                 .build();
@@ -402,7 +402,7 @@ public class CorrectionController {
         userActionAuditRepository.save(new UserActionAudit("correction/delete", "survey: " + id));
 
         var job = stagedJobRepository.save(StagedJob.builder().source(SourceJobType.CORRECTION)
-                .reference("Delete Survey " + id.toString()).status(StatusJobType.CORRECTION)
+                .reference("Delete Survey " + id.toString()).status(StatusJobType.CORRECTED)
                 .program(survey.getProgram())
                 .creator(user.get()).build());
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/stage/StagedJobRowDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/stage/StagedJobRowDto.java
@@ -25,5 +25,5 @@ public class StagedJobRowDto implements Serializable {
   private Timestamp created;
 
   private String creator;
-
+  
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/enums/StatusJobType.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/enums/StatusJobType.java
@@ -1,5 +1,5 @@
 package au.org.aodn.nrmn.restapi.model.db.enums;
 
 public enum StatusJobType {
-    FAILED, STAGED, PENDING, INGESTING, INGESTED, CORRECTION
+    FAILED, STAGED, PENDING, INGESTING, INGESTED, CORRECTED
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
@@ -187,7 +187,7 @@ public class SurveyCorrectionService {
                         .details(messages.stream().collect(Collectors.joining("\n")))
                         .eventType(StagedJobEventType.CORRECTED)
                         .build());
-        job.setStatus(StatusJobType.CORRECTION);
+        job.setStatus(StatusJobType.CORRECTED);
         jobRepository.save(job);
     }
 
@@ -224,7 +224,7 @@ public class SurveyCorrectionService {
                         .details(messages.stream().collect(Collectors.joining("\n")))
                         .eventType(StagedJobEventType.CORRECTED)
                         .build());
-        job.setStatus(StatusJobType.CORRECTION);
+        job.setStatus(StatusJobType.CORRECTED);
         job.setSurveyIds(surveyIds);
         jobRepository.save(job);
         surveyRepository.updateSurveyModified();

--- a/db/schema-update/16-update-job-status.sql
+++ b/db/schema-update/16-update-job-status.sql
@@ -1,0 +1,3 @@
+BEGIN TRANSACTION;
+UPDATE nrmn.staged_job SET status = 'CORRECTED' WHERE status = 'CORRECTION';
+END;

--- a/web/src/components/job/JobList.js
+++ b/web/src/components/job/JobList.js
@@ -130,7 +130,7 @@ const JobList = () => {
             rowGroup={true}
             hide={true}
             comparator={(a, b) => {
-              const status = ['STAGED', 'FAILED', 'INGESTED'];
+              const status = ['STAGED', 'INGESTED', 'CORRECTED', 'FAILED'];
               return status.indexOf(a) - status.indexOf(b);
             }}
           />


### PR DESCRIPTION
Change correction status from  "CORRECTION" to "CORRECTED" so that it matches the other job status types.
Requires a database update to be run after merge.