### PR TITLE
Record modified IDs as a range on the correction job

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/ObservationRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/ObservationRepository.java
@@ -37,6 +37,6 @@ public interface ObservationRepository
             "FROM  nrmn.ui_species_attributes   where observable_item_id in :id")
     List<UiSpeciesAttributes> getSpeciesAttributesByIds(@Param("id") int[] id);
 
-    @Query("SELECT observationId FROM Observation where surveyMethod.survey.surveyId = :surveyId")
+    @Query("SELECT observationId FROM Observation where surveyMethod.survey.surveyId = :surveyId ORDER BY observationId")
     List<Integer> findObservationIdsForSurvey(@Param("surveyId") Integer surveyId);
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
@@ -110,7 +110,8 @@ public class SurveyCorrectionServiceTest {
     void correctSurvey() {
 
         when(surveyMethodRepository.save(any())).then(s -> s.getArgument(0));
-        when(observationRepository.saveAll(any())).then(s -> s.getArgument(0));
+        when(observationRepository.saveAll(any())).thenReturn(Arrays.asList(Observation.builder().observationId(0).build()));
+        when(observationRepository.findObservationIdsForSurvey(any())).thenReturn(Arrays.asList(0));
 
         var correctedRow = rowBuilder.build();
         var correctedMeasures = Map.of(2, 5);

--- a/web/src/components/job/JobView.js
+++ b/web/src/components/job/JobView.js
@@ -112,33 +112,41 @@ const JobView = () => {
               )}
             </Grid>
           </Grid>
-          <Grid>
+          <Grid width="100%">
             {job.logs && (
               <TableContainer>
                 <Table aria-label="Event Log Table">
                   <TableHead>
                     <TableRow>
-                      <TableCell>Event Time</TableCell>
-                      <TableCell>Event</TableCell>
+                      <TableCell width="150px">Event Time</TableCell>
+                      <TableCell width="100px">Event</TableCell>
                       <TableCell>Details</TableCell>
                     </TableRow>
                   </TableHead>
                   <TableBody>
                     {job.logs.map((log) => (
                       <TableRow key={log.id}>
-                        <TableCell component="th" scope="row">
-                          {new Date(log.eventTime).toLocaleDateString('en-AU') +
-                            ' ' +
-                            new Date(log.eventTime).toLocaleTimeString('en-AU', {hour: 'numeric', minute: '2-digit'})}
+                        <TableCell component="th" scope="row" style={{verticalAlign: 'top'}}>
+                          <Typography fontFamily="Courier New" fontSize={12}>
+                            {new Date(log.eventTime).toLocaleDateString('en-AU') +
+                              ' ' +
+                              new Date(log.eventTime).toLocaleTimeString('en-AU', {hour: 'numeric', minute: '2-digit'})}
+                          </Typography>
                         </TableCell>
-                        <TableCell>{log.eventType}</TableCell>
+                        <TableCell style={{verticalAlign: 'top'}}>
+                          <Typography fontFamily="Courier New" fontSize={12} fontWeight="bold" >
+                            {log.eventType}
+                          </Typography>
+                        </TableCell>
                         <TableCell>
-                          {log.details?.split('\n').map((e) => (
-                            <div key={e}>
-                              {e}
-                              <br />
-                            </div>
-                          ))}
+                          <Typography fontFamily="Courier New" fontSize={12}>
+                            {log.details?.split('\n').map((e) => (
+                              <div key={e}>
+                                {e}
+                                <br />
+                              </div>
+                            ))}
+                          </Typography>
                         </TableCell>
                       </TableRow>
                     ))}


### PR DESCRIPTION
Instead of printing every single observation ID the log will now only record a range (unless the range is not contiguous).