### PR TITLE
Always keep filtered rows in grid during edit

### DIFF
--- a/web/src/components/import/DataSheetView.js
+++ b/web/src/components/import/DataSheetView.js
@@ -532,6 +532,12 @@ const DataSheetView = ({onIngest, isAdmin}) => {
     e.api.refreshCells();
     const filterModel = e.api.getFilterModel();
     setIsFiltered(Object.getOwnPropertyNames(filterModel).length > 0);
+    e.api.setFilterModel({
+      id: {
+        type: 'set',
+        values: e.api.getRenderedNodes().map((field) => field.id.toString())
+      }
+    });
   };
 
   const onRowDataUpdated = (e) => {


### PR DESCRIPTION
When a filter is set, immediately change the filter to be the resulting row IDs so that if any row changes it will never disappear.
This trick is already used in the Clone Row function.