### PR TITLE
Misc performance and code improvements

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SiteController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SiteController.java
@@ -36,7 +36,6 @@ import au.org.aodn.nrmn.restapi.controller.validation.ValidationError;
 import au.org.aodn.nrmn.restapi.controller.validation.ValidationErrors;
 import au.org.aodn.nrmn.restapi.dto.site.SiteDto;
 import au.org.aodn.nrmn.restapi.dto.site.SiteGetDto;
-import au.org.aodn.nrmn.restapi.dto.site.SiteListItem;
 import au.org.aodn.nrmn.restapi.dto.site.SiteOptionsDto;
 import au.org.aodn.nrmn.restapi.model.db.Site;
 import io.swagger.v3.oas.annotations.tags.Tag;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/Location.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/Location.java
@@ -1,7 +1,6 @@
 package au.org.aodn.nrmn.restapi.model.db;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/MeowEcoRegions.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/MeowEcoRegions.java
@@ -4,13 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import org.hibernate.envers.Audited;
 import org.hibernate.envers.NotAudited;
 import org.locationtech.jts.geom.MultiPolygon;
 
 import javax.persistence.*;
-
-import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
 
 @Entity
 @Data

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/Site.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/Site.java
@@ -116,7 +116,7 @@ public class Site {
 
     @Basic
     @Column(name = "is_active", columnDefinition = "boolean default false")
-    private Boolean isActive;
+    private Boolean isActive = false;
 
     @Basic
     @Column(name = "geom")

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/Site.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/model/db/Site.java
@@ -116,7 +116,7 @@ public class Site {
 
     @Basic
     @Column(name = "is_active", columnDefinition = "boolean default false")
-    private Boolean isActive = false;
+    private Boolean isActive;
 
     @Basic
     @Column(name = "geom")

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/ObservationRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/ObservationRepository.java
@@ -1,8 +1,6 @@
 package au.org.aodn.nrmn.restapi.repository;
 
 import java.util.List;
-import java.util.Collection;
-import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SiteRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/SiteRepository.java
@@ -14,7 +14,6 @@ import javax.persistence.QueryHint;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 
 import static org.hibernate.jpa.QueryHints.HINT_CACHEABLE;
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/dynamicQuery/FilterCondition.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/dynamicQuery/FilterCondition.java
@@ -3,7 +3,6 @@ package au.org.aodn.nrmn.restapi.repository.dynamicQuery;
 import au.org.aodn.nrmn.restapi.controller.transform.Field;
 import au.org.aodn.nrmn.restapi.controller.transform.Filter;
 import au.org.aodn.nrmn.restapi.controller.transform.Sorter;
-import au.org.aodn.nrmn.restapi.model.db.LocationListView;
 import au.org.aodn.nrmn.restapi.model.db.Survey;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -65,11 +64,11 @@ public abstract class FilterCondition<T> {
         }
     }
 
-    protected abstract FilterCondition applySort(List<Sorter> sort);
+    protected abstract FilterCondition<T> applySort(List<Sorter> sort);
 
-    protected abstract FilterCondition applyFilters(List<Filter> filters);
+    protected abstract FilterCondition<T> applyFilters(List<Filter> filters);
 
-    protected <T extends Enum<T> & FilterCondition.DBField> Order getItemOrdering(From<?,?> from, CriteriaBuilder criteriaBuilder, Sorter sort, Class<T> clazz) {
+    protected <E extends Enum<E> & FilterCondition.DBField> Order getItemOrdering(From<?,?> from, CriteriaBuilder criteriaBuilder, Sorter sort, Class<E> clazz) {
         Expression<Survey> e = from.get(FilterCondition.getFieldEnum(sort.getFieldName(), clazz).getDBFieldName());
         return (sort.isAsc()  ? criteriaBuilder.asc(e) : criteriaBuilder.desc(e));
     }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/dynamicQuery/ObservationFilterCondition.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/dynamicQuery/ObservationFilterCondition.java
@@ -119,12 +119,12 @@ public class ObservationFilterCondition extends FilterCondition<Observation> {
     }
 
     @Override
-    protected FilterCondition applySort(List<Sorter> sort) {
+    protected FilterCondition<Observation> applySort(List<Sorter> sort) {
         return null;
     }
 
     @Override
-    protected FilterCondition applyFilters(List<Filter> filters) {
+    protected FilterCondition<Observation> applyFilters(List<Filter> filters) {
         return null;
     }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/dynamicQuery/SiteFilterCondition.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/dynamicQuery/SiteFilterCondition.java
@@ -2,7 +2,6 @@ package au.org.aodn.nrmn.restapi.repository.dynamicQuery;
 
 import au.org.aodn.nrmn.restapi.controller.transform.Filter;
 import au.org.aodn.nrmn.restapi.controller.transform.Sorter;
-import au.org.aodn.nrmn.restapi.model.db.DiverListView;
 import au.org.aodn.nrmn.restapi.model.db.SiteListView;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -142,7 +141,8 @@ public class SiteFilterCondition extends FilterCondition<SiteListView> {
                             orders.add(getItemOrdering(root, criteriaBuilder, sortItem, SiteFilterCondition.SupportedFields.class));
                             break;
                         }
-                        default: { break; }
+                        default:
+                            break;
                     }
                 }
             });

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/repository/dynamicQuery/SurveyFilterCondition.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/repository/dynamicQuery/SurveyFilterCondition.java
@@ -262,7 +262,7 @@ public class SurveyFilterCondition extends FilterCondition<Survey> {
                         }
                         break;
                     }
-                    case DIVER_NAME:
+                    default:
                         break;
                 }
             }
@@ -485,6 +485,8 @@ public class SurveyFilterCondition extends FilterCondition<Survey> {
                             orders.add(getItemOrderingContact(root, criteriaBuilder, SupportedFields.DEPTH.getDBFieldName(), "surveyNum", sortItem.isAsc()));
                             break;
                         }
+                        default:
+                            break;
                     }
                 }
             });

--- a/web/src/components/data-entities/location/LocationList.js
+++ b/web/src/components/data-entities/location/LocationList.js
@@ -123,7 +123,7 @@ const LocationList = () => {
           rowModelType={'infinite'}
           enableCellTextSelection={true}
           onGridReady={(e) => onGridReady(e)}
-          onBodyScroll={(e) => autoSizeAll(e, false)}
+          onBodyScrollEnd={(e) => autoSizeAll(e, false)}
           onFilterChanged={(e) => stateFilterHandler.stateFilterEventHandler(gridRef, e)}
           suppressCellFocus={true}
           defaultColDef={{

--- a/web/src/components/data-entities/observable-item/ObservableItemList.js
+++ b/web/src/components/data-entities/observable-item/ObservableItemList.js
@@ -125,7 +125,7 @@ const ObservableItemList = () => {
         rowModelType={'infinite'}
         enableCellTextSelection={true}
         onGridReady={(e) => onGridReady(e)}
-        onBodyScroll={(e) => autoSizeAll(e, false)}
+        onBodyScrollEnd={(e) => autoSizeAll(e, false)}
         onFilterChanged={(e) => stateFilterHandler.stateFilterEventHandler(gridRef, e)}
         suppressCellFocus={true}
         defaultColDef={{sortable: true, resizable: true, filter: 'agTextColumnFilter', floatingFilter: true}}

--- a/web/src/components/data-entities/site/SiteList.js
+++ b/web/src/components/data-entities/site/SiteList.js
@@ -154,7 +154,7 @@ const SiteList = () => {
           rowModelType={'infinite'}
           enableCellTextSelection={true}
           onGridReady={(e) => onGridReady(e)}
-          onBodyScroll={(e) => autoSizeAll(e, false)}
+          onBodyScrollEnd={(e) => autoSizeAll(e, false)}
           onFilterChanged={(e) => stateFilterHandler.stateFilterEventHandler(gridRef, e)}
           suppressCellFocus={true}
           defaultColDef={{


### PR DESCRIPTION
Reference data grid: use onBodyScrollEnd instead of onBodyScroll so that the grid is only sized once at the end of a scroll.
API: remove unused imports, annotate some raw types and add default case to switch statements that are missing.
~Site Entity: use a Lombok default builder for setting default value of isActive.~ 
Reverted change to the site entity since the original behaviour is correct, even though there is a warning.