### PR TITLE
Datasheet and Survey Edit fixes

### DIFF
--- a/web/src/components/data-entities/survey/SurveyEdit.js
+++ b/web/src/components/data-entities/survey/SurveyEdit.js
@@ -71,16 +71,16 @@ const SurveyEdit = () => {
     fetchPrograms();
 
     async function fetchSites() {
-      await getResult('sites').then((res) => {
-        setSites(res.data);
+      await getResult('sites?pageSize=65536').then((res) => {
+        setSites(res.data?.items);
       });
     }
     fetchSites();
 
     async function fetchDivers() {
-      await getResult('divers').then((res) => {
+      await getResult('divers?pageSize=65536').then((res) => {
         setDivers(
-          res.data?.map((d) => {
+          res.data?.items.map((d) => {
             return {id: d.initials, label: d.fullName};
           })
         );


### PR DESCRIPTION
Survey Edit: use new paginated endpoint for autocomplete values
Datasheet: Set filter after edit only if filter previously set
Datasheet: Refresh cells after clone so that row numbers are updated
Datasheet: Clone the row measurements otherwise two rows point to the same values
