### PR TITLE
Corrections reference data and survey validations

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -208,7 +208,7 @@ public class CorrectionController {
             {
                 put("block", "Block is not an integer");
                 put("date", "Date format not valid");
-                put("depth", "Depth is not an interger");
+                put("depth", "Depth is not an integer");
                 put("direction", "Direction is not valid");
                 put("diver", "Diver does not exist");
                 put("latitude", "Latitude is not a decimal");

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -58,6 +58,7 @@ import au.org.aodn.nrmn.restapi.service.SurveyCorrectionService;
 import au.org.aodn.nrmn.restapi.service.formatting.SpeciesFormattingService;
 import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.service.validation.MeasurementValidation;
+import au.org.aodn.nrmn.restapi.service.validation.SiteValidation;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
 import au.org.aodn.nrmn.restapi.service.validation.SurveyValidation;
 import au.org.aodn.nrmn.restapi.service.validation.ValidationResultSet;
@@ -97,6 +98,9 @@ public class CorrectionController {
 
     @Autowired
     SiteRepository siteRepository;
+
+    @Autowired
+    SiteValidation siteValidation;
 
     @Autowired
     StagedJobLogRepository stagedJobLogRepository;
@@ -266,10 +270,14 @@ public class CorrectionController {
             // Total Checksum & Missing Data
             validation.addAll(measurementValidation.validateMeasurements(programValidation, row), false);
 
+
+            // Site distance validation
+            validation.add(siteValidation.validateSurveyAtSite(row));
+
             // FUTURE: other validations go here ..
         }
 
-        validation.addGlobal(surveyValidation.validateSurveys(programValidation, isExtended, mappedRows));
+        validation.addAll(surveyValidation.validateSurveys(programValidation, isExtended, mappedRows));
 
         long errorId = 0;
         for (var error : validation.getAll())

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -324,10 +324,11 @@ public class CorrectionController {
         var response = new ValidationResponse();
         try {
             var errors = new ArrayList<SurveyValidationError>();
-            
+            var rows = bodyDto.getRows();
+            errors.addAll(dataValidation.checkDuplicateRows(false, true, rows));
             errors.addAll(validate(bodyDto.getProgramValidation(),
                     bodyDto.getIsExtended(),
-                    mapRows(bodyDto.getRows()))
+                    mapRows(rows))
                     .getAll());
             response.setErrors(errors);
         } catch (Exception e) {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -336,8 +336,6 @@ public class CorrectionController {
                             .filter(r -> r.getKey().getSpecies().isPresent())
                             .map(r -> r.getKey().getSpecies().get())
                             .collect(Collectors.toList());
-
-            errors.addAll(dataValidation.checkDuplicateRows(false, true, rows));
             
             errors.addAll(dataValidation.checkFormatting(bodyDto.getProgramValidation(), bodyDto.getIsExtended(), false, siteCodes, observableItems, rows));
             

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -159,7 +159,6 @@ public class CorrectionController {
                 put("longitude", StagedRow::getLongitude);
                 put("method", StagedRow::getMethod);
                 put("siteCode", StagedRow::getSiteCode);
-                put("code", StagedRow::getCode);
                 put("species", StagedRow::getSpecies);
                 put("time", StagedRow::getTime);
                 put("vis", StagedRow::getVis);

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -59,6 +59,7 @@ import au.org.aodn.nrmn.restapi.service.formatting.SpeciesFormattingService;
 import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.service.validation.MeasurementValidation;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
+import au.org.aodn.nrmn.restapi.service.validation.SurveyValidation;
 import au.org.aodn.nrmn.restapi.service.validation.ValidationResultSet;
 import au.org.aodn.nrmn.restapi.util.ObjectUtils;
 import io.swagger.v3.oas.annotations.Operation;
@@ -108,6 +109,9 @@ public class CorrectionController {
 
     @Autowired
     SurveyRepository surveyRepository;
+
+    @Autowired
+    SurveyValidation surveyValidation;
 
     @Autowired
     UserActionAuditRepository userActionAuditRepository;
@@ -264,6 +268,8 @@ public class CorrectionController {
 
             // FUTURE: other validations go here ..
         }
+
+        validation.addGlobal(surveyValidation.validateSurveys(programValidation, isExtended, mappedRows));
 
         long errorId = 0;
         for (var error : validation.getAll())

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -311,14 +311,14 @@ public class CorrectionController {
             var mappedRows = mapRows(rows);
             var siteCodes = mappedRows.stream()
                             .filter(r -> r.getKey().getSite() != null)
-                            .map(r -> r.getKey().getSite().getSiteCode())
-                            .collect(Collectors.toList());
+                            .map(r -> r.getKey().getSite().getSiteCode().toLowerCase())
+                            .distinct().collect(Collectors.toList());
             var observableItems = mappedRows.stream()
                             .filter(r -> r.getKey().getSpecies().isPresent())
                             .map(r -> r.getKey().getSpecies().get())
                             .collect(Collectors.toList());
             errors.addAll(dataValidation.checkDuplicateRows(false, true, rows));
-            errors.addAll(dataValidation.checkFormatting(bodyDto.getProgramValidation(), bodyDto.getIsExtended(), siteCodes, observableItems, rows));
+            errors.addAll(dataValidation.checkFormatting(bodyDto.getProgramValidation(), bodyDto.getIsExtended(), false, siteCodes, observableItems, rows));
             errors.addAll(validate(bodyDto.getProgramValidation(), bodyDto.getIsExtended(), mappedRows).getAll());
             response.setErrors(errors);
         } catch (Exception e) {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/IngestionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/IngestionController.java
@@ -19,7 +19,7 @@ import au.org.aodn.nrmn.restapi.enums.StagedJobEventType;
 import au.org.aodn.nrmn.restapi.enums.StatusJobType;
 import au.org.aodn.nrmn.restapi.service.MaterializedViewService;
 import au.org.aodn.nrmn.restapi.service.SurveyIngestionService;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.formatting.SpeciesFormattingService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -43,9 +43,9 @@ public class IngestionController {
 
     @Autowired
     UserActionAuditRepository userActionAuditRepository;
-
+    
     @Autowired
-    private ValidationProcess validation;
+    private SpeciesFormattingService speciesFormatting;
 
     @Autowired
     private MaterializedViewService materializedViewService;
@@ -74,8 +74,8 @@ public class IngestionController {
             stagedJobLogRepository.save(stagedJobLog);
 
             var rows = rowRepository.findRowsByJobId(job.getId());
-            var species = validation.getSpeciesForRows(rows);
-            var validatedRows = validation.formatRowsWithSpecies(rows, species);
+            var species = speciesFormatting.getSpeciesForRows(rows);
+            var validatedRows = speciesFormatting.formatRowsWithSpecies(rows, species);
             
             surveyIngestionService.ingestTransaction(job, validatedRows);
             

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/StagedJobController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/StagedJobController.java
@@ -53,6 +53,7 @@ import au.org.aodn.nrmn.restapi.service.StagedRowService;
 import au.org.aodn.nrmn.restapi.service.upload.S3IO;
 import au.org.aodn.nrmn.restapi.service.upload.SpreadSheetService;
 import au.org.aodn.nrmn.restapi.service.upload.SurveyContentsHandler.ParsedSheet;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -96,6 +97,9 @@ public class StagedJobController {
     private ValidationProcess validation;
 
     @Autowired
+    private DataValidation dataValidation;
+
+    @Autowired
     private SecUserRepository userRepo;
 
     @Autowired
@@ -120,7 +124,7 @@ public class StagedJobController {
 
         if (lastRow.getTotal().equalsIgnoreCase("0")) {
             Long lastRowId = lastRow.getId();
-            var rowsToTruncate = validation.checkDuplicateRows(true, false, rowsToSave)
+            var rowsToTruncate = dataValidation.checkDuplicateRows(true, false, rowsToSave)
                     .stream()
                     .filter(v -> v.getRowIds().contains(lastRowId)).findAny();
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowFormattedMapperConfig.java
@@ -70,8 +70,11 @@ public class StagedRowFormattedMapperConfig {
 
         Converter<String, Optional<LocalTime>> toTime = ctx -> TimeUtils.parseTime(ctx.getSource());
 
-        Converter<String, Directions> toDirection = ctx -> EnumUtils.getEnumIgnoreCase(Directions.class,
-                ctx.getSource());
+        Converter<String, Directions> toDirection = ctx -> {
+            if(StringUtils.isEmpty(ctx.getSource()))
+                return Directions.O;
+            return EnumUtils.getEnumIgnoreCase(Directions.class,ctx.getSource());
+        };
 
         Converter<String, Integer> toDepth = ctx -> {
             try {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/SurveyRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/SurveyRepository.java
@@ -48,10 +48,10 @@ public interface SurveyRepository extends JpaRepository<Survey, Integer>, JpaSpe
                                 v.getSite().getLocation().getLocationName()));
         }
 
-        @Query("SELECT s FROM #{#entityName} s " + "WHERE s.site = :site " + "  AND s.depth = :depth "
+        @Query("SELECT s.surveyId FROM #{#entityName} s " + "WHERE s.site = :site " + "  AND s.depth = :depth "
                         + "  AND s.surveyNum = :surveyNum " + "  AND s.surveyDate = :date")
         @QueryHints({ @QueryHint(name = HINT_CACHEABLE, value = "true") })
-        List<Survey> findBySiteDepthSurveyNumDate(@Param("site") Site site, @Param("depth") Integer depth,
+        List<Long> findBySiteDepthSurveyNumDate(@Param("site") Site site, @Param("depth") Integer depth,
                         @Param("surveyNum") Integer surveyNum, @Param("date") Date date);
 
         @Query("SELECT s FROM Survey s WHERE s.surveyId IN :ids AND (s.pqCatalogued = FALSE OR s.pqCatalogued IS NULL)")

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/enums/ValidationCategory.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/enums/ValidationCategory.java
@@ -1,5 +1,5 @@
 package au.org.aodn.nrmn.restapi.enums;
 
 public enum ValidationCategory {
-    FORMAT, DATA, ENTITY, RUNTIME, SPAN
+    FORMAT, DATA, SPAN
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyEditService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyEditService.java
@@ -167,13 +167,15 @@ public class SurveyEditService {
                     "Longitude must contain a valid number"));
         }
 
-        boolean hasValidCoords = lat != null && lon != null && !lat.isNaN() && !lon.isNaN();
-        double distMeters = hasValidCoords ? getDistanceLatLongMeters(lat, lon, surveyDtoSite.getLatitude(), surveyDtoSite.getLongitude()) : 0;
-        if(distMeters > 200){
-            errors.add(new FormValidationError("Survey", "latitude", surveyDto.getLatitude(),
-                    String.format("Coordinates are further than 200m from the Site (%.2fm)", distMeters)));
-            errors.add(new FormValidationError("Survey", "longitude", surveyDto.getLongitude(),
-                    String.format("Coordinates are further than 200m from the Site (%.2fm)", distMeters)));
+        var hasValidCoords = lat != null && lon != null && !lat.isNaN() && !lon.isNaN();
+        if(hasValidCoords) {
+            var distMeters = hasValidCoords ? getDistanceLatLongMeters(lat, lon, surveyDtoSite.getLatitude(), surveyDtoSite.getLongitude()) : 0;
+            if(distMeters > 200){
+                errors.add(new FormValidationError("Survey", "latitude", surveyDto.getLatitude(),
+                        String.format("Coordinates are further than 200m from the Site (%.2fm)", distMeters)));
+                errors.add(new FormValidationError("Survey", "longitude", surveyDto.getLongitude(),
+                        String.format("Coordinates are further than 200m from the Site (%.2fm)", distMeters)));
+            }
         }
 
         if(lat != null && !lat.isNaN() && (lat < -90 || lat > 90) ) {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyEditService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyEditService.java
@@ -194,9 +194,9 @@ public class SurveyEditService {
 
         // Ensure site/date/depth.surveyNum is unique
         Integer depth = surveyDto.getDepth() != null && surveyDto.getDepth().length() > 0 ? Integer.valueOf(surveyDto.getDepth()) : null;
-        List<Survey> duplicateSurveys = surveyRepository.findBySiteDepthSurveyNumDate(
+        var duplicateSurveys = surveyRepository.findBySiteDepthSurveyNumDate(
                 surveyDtoSite, depth, surveyDto.getSurveyNum(), surveyDate).stream()
-                .filter(s -> !s.getSurveyId().equals(surveyDto.getSurveyId()))
+                .filter(surveyId -> !surveyId.equals(Integer.toUnsignedLong(surveyDto.getSurveyId())))
                 .collect(Collectors.toList());
 
         if (duplicateSurveys.size() > 0) {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/formatting/SpeciesFormattingService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/formatting/SpeciesFormattingService.java
@@ -1,0 +1,65 @@
+package au.org.aodn.nrmn.restapi.service.formatting;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import au.org.aodn.nrmn.restapi.controller.mapping.StagedRowFormattedMapperConfig;
+import au.org.aodn.nrmn.restapi.data.model.ObservableItem;
+import au.org.aodn.nrmn.restapi.data.model.StagedRow;
+import au.org.aodn.nrmn.restapi.data.model.UiSpeciesAttributes;
+import au.org.aodn.nrmn.restapi.data.repository.DiverRepository;
+import au.org.aodn.nrmn.restapi.data.repository.ObservableItemRepository;
+import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
+import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
+import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
+
+@Service
+public class SpeciesFormattingService {
+
+    @Autowired
+    ObservationRepository observationRepository;
+
+    @Autowired
+    ObservableItemRepository observableItemRepository;
+    
+    @Autowired
+    DiverRepository diverRepository;
+
+    @Autowired
+    SiteRepository siteRepository;
+
+    public Collection<ObservableItem> getSpeciesForRows(Collection<StagedRow> rows) {
+        var enteredSpeciesNames = rows.stream().map(s -> s.getSpecies()).collect(Collectors.toSet());
+        return observableItemRepository.getAllSpeciesNamesMatching(enteredSpeciesNames);
+    }
+
+    public List<StagedRowFormatted> formatRowsWithSpecies(Collection<StagedRow> rows,
+            Collection<ObservableItem> species) {
+
+        var rowMap = rows.stream().collect(Collectors.toMap(StagedRow::getId, r -> r));
+
+        var speciesIds = species.stream()
+                .mapToInt(s -> s.getObservableItemId())
+                .toArray();
+
+        var speciesAttributesMap = observationRepository
+                .getSpeciesAttributesByIds(speciesIds).stream()
+                .collect(Collectors.toMap(UiSpeciesAttributes::getSpeciesName, a -> a));
+
+        var speciesMap = species.stream().collect(Collectors.toMap(ObservableItem::getObservableItemName, o -> o));
+
+        var divers = diverRepository.getAll().stream().collect(Collectors.toList());
+
+        var sites = siteRepository.getAll().stream().collect(Collectors.toList());
+
+        var mapperConfig = new StagedRowFormattedMapperConfig();
+        var mapper = mapperConfig.getModelMapper(speciesMap, rowMap, speciesAttributesMap, divers, sites);
+
+        return rows.stream().map(stagedRow -> mapper.map(stagedRow, StagedRowFormatted.class))
+                .collect(Collectors.toList());
+    }
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
@@ -1,0 +1,266 @@
+package au.org.aodn.nrmn.restapi.service.validation;
+
+import java.text.Normalizer;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.EnumUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import au.org.aodn.nrmn.restapi.data.model.ObservableItem;
+import au.org.aodn.nrmn.restapi.data.model.StagedRow;
+import au.org.aodn.nrmn.restapi.data.repository.DiverRepository;
+import au.org.aodn.nrmn.restapi.data.repository.ObservableItemRepository;
+import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
+import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
+import au.org.aodn.nrmn.restapi.data.repository.StagedRowRepository;
+import au.org.aodn.nrmn.restapi.data.repository.SurveyRepository;
+import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
+import au.org.aodn.nrmn.restapi.enums.Directions;
+import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
+import au.org.aodn.nrmn.restapi.enums.ValidationLevel;
+import au.org.aodn.nrmn.restapi.util.TimeUtils;
+
+@Service
+public class DataValidation {
+
+    @Autowired
+    DiverRepository diverRepository;
+
+    @Autowired
+    ObservableItemRepository observableItemRepository;
+
+    @Autowired
+    ObservationRepository observationRepository;
+
+    @Autowired
+    SiteRepository siteRepository;
+
+    @Autowired
+    StagedRowRepository rowRepository;
+
+    @Autowired
+    SurveyRepository surveyRepository;
+
+    @Autowired
+    MeasurementValidation speciesMeasurement;
+
+    private static final int INVALID_INT = Integer.MIN_VALUE;
+    private static final double INVALID_DOUBLE = Double.NEGATIVE_INFINITY;
+    private static final Pattern VALID_DEPTH_SURVEY_NUM = Pattern.compile("^[0-9]+(\\.[0-9])?$");
+
+    // VALIDATION: Rows duplicated
+    public Collection<SurveyValidationError> checkDuplicateRows(boolean includeTotal, boolean includeSpeciesCode,
+            Collection<StagedRow> rows) {
+        var mappedRows = new HashMap<String, List<Long>>();
+        var mappedSpecies = new HashMap<String, String>();
+        rows.stream().forEach(r -> {
+            String rowHash = r.getContentsHash(includeTotal, includeSpeciesCode);
+            List<Long> rowIds = mappedRows.getOrDefault(rowHash, new ArrayList<Long>());
+            rowIds.add(r.getId());
+            if (!mappedSpecies.containsKey(rowHash))
+                mappedSpecies.put(rowHash, r.getSpecies());
+            mappedRows.put(rowHash, rowIds);
+        });
+        var duplicateRows = new ArrayList<SurveyValidationError>();
+        mappedRows.forEach((r, v) -> {
+            if (v.size() > 1) {
+                List<Long> rowIds = v.stream().collect(Collectors.toList());
+                duplicateRows.add(
+                        new SurveyValidationError(null, ValidationLevel.DUPLICATE, mappedSpecies.get(r), rowIds, null));
+
+            }
+        });
+        return duplicateRows;
+    }
+
+    public Collection<SurveyValidationError> checkFormatting(ProgramValidation validation, Boolean isExtendedSize,
+            Collection<String> siteCodes, Collection<ObservableItem> species, Collection<StagedRow> rows) {
+
+        var diverNames = new ArrayList<String>();
+        for (var d : diverRepository.getAll()) {
+            diverNames.add(Normalizer.normalize(d.getFullName(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
+                    .toUpperCase());
+            diverNames.add(Normalizer.normalize(d.getInitials(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
+                    .toUpperCase());
+        }
+
+        var errors = new ValidationResultSet();
+
+        errors.addGlobal(checkDuplicateRows(false, true, rows));
+
+        for (var row : rows) {
+
+            var rowId = row.getId();
+
+            // Site
+            if (row.getSiteCode() == null || !siteCodes.contains(row.getSiteCode().toLowerCase()))
+                errors.add(rowId, ValidationLevel.BLOCKING, "siteCode", "Site Code does not exist");
+
+            // Diver
+            if (row.getDiver() == null || !diverNames.contains(Normalizer.normalize(row.getDiver(), Normalizer.Form.NFD)
+                    .replaceAll("[^\\p{ASCII}]", "").toUpperCase()))
+                errors.add(rowId, ValidationLevel.BLOCKING, "diver", "Diver does not exist");
+
+            // Buddies
+            var unknownBuddies = new ArrayList<String>();
+            if (StringUtils.isNotEmpty(row.getBuddy())) {
+                for (String buddyComponent : row.getBuddy().split(",")) {
+                    String buddy = buddyComponent.trim();
+                    if (!diverNames.contains(Normalizer.normalize(buddy, Normalizer.Form.NFD)
+                            .replaceAll("[^\\p{ASCII}]", "").toUpperCase()))
+                        unknownBuddies.add(buddy);
+                }
+            }
+
+            if (StringUtils.isEmpty(row.getBuddy())) {
+                errors.add(rowId, ValidationLevel.WARNING, "buddy", "Diver does not exist", 0);
+            } else if (unknownBuddies.size() == 1) {
+                errors.add(rowId, ValidationLevel.WARNING, "buddy",
+                        "Diver " + unknownBuddies.get(0) + " does not exist", 1);
+            } else if (unknownBuddies.size() > 1) {
+                errors.add(rowId, ValidationLevel.WARNING, "buddy",
+                        "Divers " + String.join(", ", unknownBuddies) + " do not exist", unknownBuddies.size());
+            }
+
+            if (StringUtils.isBlank(row.getPqs())) {
+                errors.add(rowId, ValidationLevel.WARNING, "P-Qs", "P-Qs Diver is blank");
+            } else if (!diverNames.contains(Normalizer.normalize(row.getPqs(), Normalizer.Form.NFD)
+                    .replaceAll("[^\\p{ASCII}]", "").toUpperCase())) {
+                errors.add(rowId, ValidationLevel.WARNING, "P-Qs",
+                        String.format("Diver \"%s\" does not exist", row.getPqs()));
+            }
+
+            // VALIDATION: Species are not superseded
+            if (StringUtils.isNotEmpty(row.getSpecies()) && !row.getSpecies().equalsIgnoreCase("survey not done")) {
+                Optional<ObservableItem> observableItem = species.stream()
+                        .filter(s -> row.getSpecies().equalsIgnoreCase(s.getObservableItemName())).findAny();
+                if (observableItem.isPresent()) {
+                    String supersededBy = observableItem.get().getSupersededBy();
+                    if (StringUtils.isNotEmpty(supersededBy))
+                        errors.add(rowId, ValidationLevel.WARNING, "species", "Superseded by " + supersededBy);
+                } else {
+                    errors.add(rowId, ValidationLevel.BLOCKING, "species", "Species does not exist");
+                }
+            }
+
+            // Direction
+            if (StringUtils.isNotEmpty(row.getDirection())
+                    && !EnumUtils.isValidEnumIgnoreCase(Directions.class, row.getDirection())
+                    && !Arrays.asList("0", "").contains(row.getDirection()))
+                errors.add(rowId, ValidationLevel.BLOCKING, "direction", "Direction is not valid");
+
+            // Latitude
+            var latitude = NumberUtils.toDouble(row.getLatitude(), INVALID_DOUBLE);
+            if (latitude < -90.0 || 90.0 < latitude || latitude == INVALID_DOUBLE)
+                errors.add(rowId, ValidationLevel.BLOCKING, "latitude",
+                        (latitude == INVALID_DOUBLE) ? "Latitude is not number" : "Latitude is out of bounds");
+
+            // Longitude
+            var longitude = NumberUtils.toDouble(row.getLongitude(), INVALID_DOUBLE);
+            if (longitude < -180 || 180 < longitude || longitude == INVALID_DOUBLE)
+                errors.add(rowId, ValidationLevel.BLOCKING, "longitude",
+                        (latitude == INVALID_DOUBLE) ? "Longitude is not number" : "Longitude is out of bounds");
+
+            // Date
+            try {
+                LocalDate.parse(row.getDate(), TimeUtils.getRowDateFormatter());
+            } catch (DateTimeParseException e) {
+                errors.add(rowId, ValidationLevel.BLOCKING, "date", "Date format is not valid");
+            }
+
+            // Time
+            if (row.getTime().length() > 0 && !TimeUtils.parseTime(row.getTime()).isPresent())
+                errors.add(rowId, ValidationLevel.WARNING, "time", "Time format is not valid");
+
+            // Block
+            if (!Arrays.asList(0, 1, 2).contains(NumberUtils.toInt(row.getBlock(), INVALID_INT))) {
+                errors.add(rowId, ValidationLevel.BLOCKING, "block", "Block must be 0, 1 or 2");
+            }
+
+            // Vis
+            if (!StringUtils.isBlank(row.getVis())) {
+                Double vis = NumberUtils.toDouble(row.getVis(), (double) INVALID_INT);
+                if (vis < 0) {
+                    errors.add(rowId, ValidationLevel.BLOCKING, "vis",
+                            (vis == (double) INVALID_INT) ? "Vis is not a decimal" : "Vis is not positive");
+                } else {
+                    if (vis.toString().split("\\.")[1].length() > 1)
+                        errors.add(rowId, ValidationLevel.BLOCKING, "vis", "Vis is more than one decimal place");
+                }
+            }
+
+            // Inverts
+            var inverts = NumberUtils.toInt(row.getInverts(), INVALID_INT);
+            if (inverts == INVALID_INT)
+                errors.add(rowId, ValidationLevel.BLOCKING, "inverts", "Inverts is not an integer");
+
+            // Total
+            if (NumberUtils.toInt(row.getTotal(), INVALID_INT) == INVALID_INT)
+                errors.add(rowId, ValidationLevel.BLOCKING, "total", "Total is not an integer");
+
+            // Method
+            if (NumberUtils.toInt(row.getMethod(), INVALID_INT) == INVALID_INT)
+                errors.add(rowId, ValidationLevel.BLOCKING, "method", "Method is not an integer");
+
+            // MeasureJson
+            if (row.getMeasureJson() != null)
+                row.getMeasureJson().entrySet().stream().forEach(measure -> {
+                    if (!StringUtils.isBlank(measure.getValue())
+                            && NumberUtils.toInt(measure.getValue(), INVALID_INT) < 0)
+                        errors.add(rowId, ValidationLevel.BLOCKING, measure.getKey().toString(),
+                                "Measurement is not valid");
+                });
+
+            // Depth
+            if (StringUtils.isBlank(row.getDepth()) || !VALID_DEPTH_SURVEY_NUM.matcher(row.getDepth()).matches())
+                errors.add(rowId, ValidationLevel.BLOCKING, "depth", "Depth is invalid, expected: depth[.surveyNum]");
+
+            // RLS Method
+            if (validation == ProgramValidation.RLS
+                    && !Arrays.asList(0, 1, 2, 10).contains(NumberUtils.toInt(row.getMethod(), INVALID_INT)))
+                errors.add(rowId, ValidationLevel.BLOCKING, "method", "RLS Method must be 0, 1, 2 or 10");
+
+            // Block 0
+            if (row.getBlock().equalsIgnoreCase("0")
+                    && !Arrays.asList(0, 3, 4, 5).contains(NumberUtils.toInt(row.getMethod(), INVALID_INT)))
+                errors.add(rowId, ValidationLevel.BLOCKING, "block", "Block 0 is invalid for method");
+
+            // ATRC Method
+            if (validation == ProgramValidation.ATRC) {
+                if (!Arrays.asList(0, 1, 2, 3, 4, 5, 7, 10).contains(NumberUtils.toInt(row.getMethod(), INVALID_INT)))
+                    errors.add(rowId, ValidationLevel.BLOCKING, "method", "ATRC Method must be [0-5], 7 or 10");
+
+                if (NumberUtils.toInt(row.getMethod()) == 7 && NumberUtils.toInt(row.getBlock()) != 2)
+                    errors.add(rowId, ValidationLevel.BLOCKING, "method", "ATRC Method 7 must be recorded on block 2");
+            }
+
+            // Validation: Use Invert Sizing is blank
+            if (isExtendedSize && StringUtils.isBlank(row.getIsInvertSizing())) {
+                errors.add(rowId, ValidationLevel.WARNING, "isInvertSizing", "Use Invert Sizing is blank");
+            }
+
+            // Validation: Species Invert Sizing
+            if (isExtendedSize && !StringUtils.isBlank(row.getIsInvertSizing()) &&
+                    !(row.getIsInvertSizing().equalsIgnoreCase("YES")
+                            || row.getIsInvertSizing().equalsIgnoreCase("NO")))
+                errors.add(rowId, ValidationLevel.BLOCKING, "isInvertSizing",
+                        "Use Invert Sizing must be 'Yes' or 'No'");
+
+        }
+
+        return errors.getAll();
+    }
+
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
@@ -102,7 +102,7 @@ public class DataValidation {
 
         var errors = new ValidationResultSet();
 
-        errors.addGlobal(checkDuplicateRows(false, true, rows));
+        errors.addAll(checkDuplicateRows(false, true, rows));
 
         for (var row : rows) {
 
@@ -130,13 +130,13 @@ public class DataValidation {
 
             if (checkBuddy) {
                 if (StringUtils.isEmpty(row.getBuddy())) {
-                    errors.add(rowId, ValidationLevel.WARNING, "buddy", "Diver does not exist", 0);
+                    errors.add(rowId, ValidationLevel.WARNING, "buddy", "Diver does not exist");
                 } else if (unknownBuddies.size() == 1) {
                     errors.add(rowId, ValidationLevel.WARNING, "buddy",
-                            "Diver " + unknownBuddies.get(0) + " does not exist", 1);
+                            "Diver " + unknownBuddies.get(0) + " does not exist");
                 } else if (unknownBuddies.size() > 1) {
                     errors.add(rowId, ValidationLevel.WARNING, "buddy",
-                            "Divers " + String.join(", ", unknownBuddies) + " do not exist", unknownBuddies.size());
+                            "Divers " + String.join(", ", unknownBuddies) + " do not exist");
                 }
             }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
@@ -87,7 +87,7 @@ public class DataValidation {
 
     public Collection<SurveyValidationError> checkFormatting(ProgramValidation validation,
             Boolean isExtendedSize,
-            Boolean checkBuddy,
+            Boolean isIngest,
             Collection<String> siteCodes,
             Collection<ObservableItem> species,
             Collection<StagedRow> rows) {
@@ -128,7 +128,8 @@ public class DataValidation {
                 }
             }
 
-            if (checkBuddy) {
+            if (isIngest) {
+                
                 if (StringUtils.isEmpty(row.getBuddy())) {
                     errors.add(rowId, ValidationLevel.WARNING, "buddy", "Diver does not exist");
                 } else if (unknownBuddies.size() == 1) {
@@ -138,6 +139,10 @@ public class DataValidation {
                     errors.add(rowId, ValidationLevel.WARNING, "buddy",
                             "Divers " + String.join(", ", unknownBuddies) + " do not exist");
                 }
+
+                // Total
+                if (NumberUtils.toInt(row.getTotal(), INVALID_INT) == INVALID_INT)
+                    errors.add(rowId, ValidationLevel.BLOCKING, "total", "Total is not an integer");
             }
 
             if (StringUtils.isBlank(row.getPqs())) {
@@ -211,10 +216,6 @@ public class DataValidation {
             var inverts = NumberUtils.toInt(row.getInverts(), INVALID_INT);
             if (inverts == INVALID_INT)
                 errors.add(rowId, ValidationLevel.BLOCKING, "inverts", "Inverts is not an integer");
-
-            // Total
-            if (NumberUtils.toInt(row.getTotal(), INVALID_INT) == INVALID_INT)
-                errors.add(rowId, ValidationLevel.BLOCKING, "total", "Total is not an integer");
 
             // Method
             if (NumberUtils.toInt(row.getMethod(), INVALID_INT) == INVALID_INT)

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
@@ -85,8 +85,12 @@ public class DataValidation {
         return duplicateRows;
     }
 
-    public Collection<SurveyValidationError> checkFormatting(ProgramValidation validation, Boolean isExtendedSize,
-            Collection<String> siteCodes, Collection<ObservableItem> species, Collection<StagedRow> rows) {
+    public Collection<SurveyValidationError> checkFormatting(ProgramValidation validation,
+            Boolean isExtendedSize,
+            Boolean checkBuddy,
+            Collection<String> siteCodes,
+            Collection<ObservableItem> species,
+            Collection<StagedRow> rows) {
 
         var diverNames = new ArrayList<String>();
         for (var d : diverRepository.getAll()) {
@@ -124,14 +128,16 @@ public class DataValidation {
                 }
             }
 
-            if (StringUtils.isEmpty(row.getBuddy())) {
-                errors.add(rowId, ValidationLevel.WARNING, "buddy", "Diver does not exist", 0);
-            } else if (unknownBuddies.size() == 1) {
-                errors.add(rowId, ValidationLevel.WARNING, "buddy",
-                        "Diver " + unknownBuddies.get(0) + " does not exist", 1);
-            } else if (unknownBuddies.size() > 1) {
-                errors.add(rowId, ValidationLevel.WARNING, "buddy",
-                        "Divers " + String.join(", ", unknownBuddies) + " do not exist", unknownBuddies.size());
+            if (checkBuddy) {
+                if (StringUtils.isEmpty(row.getBuddy())) {
+                    errors.add(rowId, ValidationLevel.WARNING, "buddy", "Diver does not exist", 0);
+                } else if (unknownBuddies.size() == 1) {
+                    errors.add(rowId, ValidationLevel.WARNING, "buddy",
+                            "Diver " + unknownBuddies.get(0) + " does not exist", 1);
+                } else if (unknownBuddies.size() > 1) {
+                    errors.add(rowId, ValidationLevel.WARNING, "buddy",
+                            "Divers " + String.join(", ", unknownBuddies) + " do not exist", unknownBuddies.size());
+                }
             }
 
             if (StringUtils.isBlank(row.getPqs())) {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
@@ -162,7 +162,7 @@ public class DataValidation {
             }
 
             // Direction
-            if (StringUtils.isNotEmpty(row.getDirection())
+            if (row.getDirection() != null && StringUtils.isNotEmpty(row.getDirection())
                     && !EnumUtils.isValidEnumIgnoreCase(Directions.class, row.getDirection())
                     && !Arrays.asList("0", "").contains(row.getDirection()))
                 errors.add(rowId, ValidationLevel.BLOCKING, "direction", "Direction is not valid");
@@ -187,7 +187,7 @@ public class DataValidation {
             }
 
             // Time
-            if (row.getTime().length() > 0 && !TimeUtils.parseTime(row.getTime()).isPresent())
+            if (row.getTime() != null && row.getTime().length() > 0 && !TimeUtils.parseTime(row.getTime()).isPresent())
                 errors.add(rowId, ValidationLevel.WARNING, "time", "Time format is not valid");
 
             // Block

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/MeasurementValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/MeasurementValidation.java
@@ -165,7 +165,8 @@ public class MeasurementValidation {
                 errors.addAll(validateMeasureUnderMax(isExtended, row, speciesAttributes));
                 errors.addAll(validateAbundance(row, speciesAttributes));
             } else {
-                errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING,
+                if(row.getInverts() < 1)
+                    errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING,
                         "Row contains no measurements", row.getId(), "measurements.1"));
             }
         }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/MeasurementValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/MeasurementValidation.java
@@ -165,7 +165,7 @@ public class MeasurementValidation {
                 errors.addAll(validateMeasureUnderMax(isExtended, row, speciesAttributes));
                 errors.addAll(validateAbundance(row, speciesAttributes));
             } else {
-                if(row.getInverts() < 1)
+                if(row.getInverts() == null || row.getInverts() < 1)
                     errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING,
                         "Row contains no measurements", row.getId(), "measurements.1"));
             }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SiteValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SiteValidation.java
@@ -1,0 +1,29 @@
+package au.org.aodn.nrmn.restapi.service.validation;
+
+import static au.org.aodn.nrmn.restapi.util.SpacialUtil.getDistanceLatLongMeters;
+
+import java.util.Arrays;
+
+import org.springframework.stereotype.Service;
+
+import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
+import au.org.aodn.nrmn.restapi.enums.ValidationCategory;
+import au.org.aodn.nrmn.restapi.enums.ValidationLevel;
+
+@Service
+public class SiteValidation {
+
+    // VALIDATION: Survey coordinates match site coordinates
+    public SurveyValidationError validateSurveyAtSite(StagedRowFormatted row) {
+
+        var distMeters = getDistanceLatLongMeters(row.getSite().getLatitude(), row.getSite().getLongitude(), row.getLatitude(), row.getLongitude());
+
+        // Warn if survey is more than 10 meters away from site
+        if (distMeters > 10) {
+            var message = "Survey coordinates more than 10m from site (" + String.format("%.1f", distMeters) + "m)";
+            return new SurveyValidationError(ValidationCategory.DATA, ValidationLevel.WARNING, message, Arrays.asList(row.getId()),Arrays.asList("latitude","longitude"));
+        }
+
+        return null;
+    }
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SiteValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SiteValidation.java
@@ -16,12 +16,15 @@ public class SiteValidation {
     // VALIDATION: Survey coordinates match site coordinates
     public SurveyValidationError validateSurveyAtSite(StagedRowFormatted row) {
 
-        var distMeters = getDistanceLatLongMeters(row.getSite().getLatitude(), row.getSite().getLongitude(), row.getLatitude(), row.getLongitude());
+        var site = row.getSite();
+        if(site != null) {
+            var distMeters = getDistanceLatLongMeters(row.getSite().getLatitude(), row.getSite().getLongitude(), row.getLatitude(), row.getLongitude());
 
-        // Warn if survey is more than 10 meters away from site
-        if (distMeters > 10) {
-            var message = "Survey coordinates more than 10m from site (" + String.format("%.1f", distMeters) + "m)";
-            return new SurveyValidationError(ValidationCategory.DATA, ValidationLevel.WARNING, message, Arrays.asList(row.getId()),Arrays.asList("latitude","longitude"));
+            // Warn if survey is more than 10 meters away from site
+            if (distMeters > 10) {
+                var message = "Survey coordinates more than 10m from site (" + String.format("%.1f", distMeters) + "m)";
+                return new SurveyValidationError(ValidationCategory.DATA, ValidationLevel.WARNING, message, Arrays.asList(row.getId()),Arrays.asList("latitude","longitude"));
+            }
         }
 
         return null;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/StagedRowFormatted.java
@@ -25,7 +25,9 @@ import au.org.aodn.nrmn.restapi.enums.Directions;
 @Builder
 @AllArgsConstructor
 public class StagedRowFormatted {
-    private long id;
+    private Long id;
+
+    private Long surveyId;
 
     private Site site;
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/StagedRowFormatted.java
@@ -89,7 +89,6 @@ public class StagedRowFormatted {
                 && Objects.equals(species, that.species);
     }
 
-    
     public Boolean isDebrisZero() {
         return ((code != null && code.equalsIgnoreCase("DEZ")) || (ref != null && ref.getSpecies().equalsIgnoreCase("Debris - Zero")));
     }
@@ -115,6 +114,6 @@ public class StagedRowFormatted {
     }
 
     public Integer observationTotal() { 
-        return getMeasureJson().entrySet().stream().map(Map.Entry::getValue).reduce(0, Integer::sum) + (getInverts() != null ? getInverts() : 0);
+        return getMeasureJson().entrySet().stream().mapToInt(Map.Entry::getValue).sum() + (getInverts() != null ? getInverts() : 0);
     }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
@@ -1,0 +1,8 @@
+package au.org.aodn.nrmn.restapi.service.validation;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class SurveyValidation {
+    
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
@@ -103,8 +103,7 @@ public class SurveyValidation {
                     "Method 0 must have block 0, 1 or 2",
                     method0Rows.stream().map(r -> r.getId()).collect(Collectors.toList()), Arrays.asList("block"));
 
-        // VALIDATION: Both M1, M2 present and if ATRC has M3 and at least one method of
-        // 3,4,5,7
+        // VALIDATION: M1, M2 (and M3 if ATRC) are present
         var requiredMethods = validation == ProgramValidation.ATRC ? Arrays.asList(1, 2, 3) : Arrays.asList(1, 2);
         var missingMethods = new ArrayList<Integer>(requiredMethods);
         missingMethods.removeAll(surveyByMethod.keySet());
@@ -115,7 +114,7 @@ public class SurveyValidation {
             flagColumns.add("method");
         }
 
-        // VALIDATION: M1, M2 each has B1, B2 and if ATRC M3 has B0
+        // VALIDATION: M1, M2 each have B1, B2 (and M3 has B0 if ATRC)
         var methodsRequired = validation == ProgramValidation.RLS ? Arrays.asList(1, 2) : Arrays.asList(1, 2, 3);
         var level = ValidationLevel.WARNING;
         for (var method : methodsRequired) {
@@ -165,7 +164,7 @@ public class SurveyValidation {
         }
         return null;
     }
-    
+
     private SurveyValidationError validateSurveyIsNew(StagedRowFormatted row) {
         if (row.getDate() != null && Arrays.asList(METHODS_TO_CHECK).contains(row.getMethod())) {
 
@@ -244,7 +243,8 @@ public class SurveyValidation {
         return res;
     }
 
-    public Collection<SurveyValidationError> validateSurveys(ProgramValidation validation, Boolean isExtended, Collection<StagedRowFormatted> mappedRows) {
+    public Collection<SurveyValidationError> validateSurveys(ProgramValidation validation, Boolean isExtended,
+            Collection<StagedRowFormatted> mappedRows) {
         var sheetErrors = new HashSet<SurveyValidationError>();
 
         var surveyMap = mappedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurvey));
@@ -259,7 +259,8 @@ public class SurveyValidation {
         return sheetErrors;
     }
 
-    public Collection<SurveyValidationError> validateSurveyGroups(ProgramValidation validation, Boolean isExtended, Collection<StagedRowFormatted> mappedRows) {
+    public Collection<SurveyValidationError> validateSurveyGroups(ProgramValidation validation, Boolean isExtended,
+            Collection<StagedRowFormatted> mappedRows) {
         var sheetErrors = new HashSet<SurveyValidationError>();
 
         var surveyGroupMap = mappedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurveyGroup));

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
@@ -1,8 +1,265 @@
 package au.org.aodn.nrmn.restapi.service.validation;
 
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import au.org.aodn.nrmn.restapi.data.repository.SurveyRepository;
+import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
+import au.org.aodn.nrmn.restapi.dto.stage.ValidationCell;
+import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
+import au.org.aodn.nrmn.restapi.enums.ValidationCategory;
+import au.org.aodn.nrmn.restapi.enums.ValidationLevel;
 
 @Service
 public class SurveyValidation {
-    
+
+    @Autowired
+    SurveyRepository surveyRepository;
+
+    private static final Integer[] METHODS_TO_CHECK = { 0, 1, 2, 7, 10 };
+
+    public SurveyValidationError validateMethod3Quadrats(String transect, List<StagedRowFormatted> rows) {
+
+        var columnNames = new HashSet<String>();
+        var rowIds = new HashSet<Long>();
+
+        for (int measureIndex : Arrays.asList(1, 2, 3, 4, 5))
+            if (rows.stream().mapToInt(row -> row.getMeasureJson().getOrDefault(measureIndex, 0)).sum() == 0) {
+                rowIds.addAll(rows.stream().map(r -> r.getId()).collect(Collectors.toList()));
+                columnNames.add(Integer.toString(measureIndex));
+            }
+
+        return rowIds.size() > 0 ? new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.BLOCKING,
+                "Missing quadrats in transect " + transect, rowIds, columnNames) : null;
+    }
+
+    public Collection<ValidationCell> validateMethod3QuadratsLT50(List<StagedRowFormatted> rows) {
+        var errors = new ArrayList<ValidationCell>();
+
+        for (int measureIndex : Arrays.asList(1, 2, 3, 4, 5))
+            for (var row : rows) {
+                if (row.getMeasureJson().getOrDefault(measureIndex, 0) > 50)
+                    errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING,
+                            "M3 quadrat more than 50", row.getId(), Integer.toString(measureIndex)));
+            }
+
+        return errors;
+    }
+
+    public SurveyValidationError validateMethod3QuadratsGT50(String transect, List<StagedRowFormatted> rows) {
+
+        var columnNames = new HashSet<String>();
+
+        for (var measureIndex : Arrays.asList(1, 2, 3, 4, 5)) {
+            if (rows.stream().mapToInt(row -> row.getMeasureJson().getOrDefault(measureIndex, 0)).sum() < 50)
+                columnNames.add(Integer.toString(measureIndex));
+        }
+
+        var rowIds = rows.stream().map(r -> r.getId()).collect(Collectors.toList());
+        return columnNames.size() > 0 ? new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.BLOCKING,
+                "Quadrats do not sum to at least 50 in transect " + transect, rowIds, columnNames) : null;
+    }
+
+    public SurveyValidationError validateSurveyTransectNumber(List<StagedRowFormatted> surveyRows) {
+        var invalidTransectRows = surveyRows.stream()
+                .filter(r -> !Arrays.asList(1, 2, 3, 4).contains(r.getSurveyNum())).collect(Collectors.toList());
+        if (invalidTransectRows.size() > 0)
+            return new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING,
+                    "Survey group transect invalid",
+                    invalidTransectRows.stream().map(r -> r.getId()).collect(Collectors.toList()),
+                    Arrays.asList("depth"));
+        return null;
+    }
+
+    private SurveyValidationError validateSurveyComplete(ProgramValidation validation,
+            List<StagedRowFormatted> surveyRows) {
+
+        if (surveyRows.stream().anyMatch(r -> r.getMethod() == null || r.getBlock() == null))
+            return null;
+
+        var messagePrefix = "Survey incomplete: " + surveyRows.get(0).getDecimalSurvey();
+
+        var surveyByMethod = surveyRows.stream().filter(sr -> sr.getMethod() != null && sr.getBlock() != null)
+                .collect(Collectors.groupingBy(StagedRowFormatted::getMethod));
+
+        var rowIds = new HashSet<Long>();
+        var flagColumns = new HashSet<String>();
+        var messages = new ArrayList<String>();
+
+        // VALIDATION: If method = 0 then Block should be 0, 1 or 2
+        var method0Rows = surveyByMethod.get(0);
+        if (method0Rows != null && method0Rows.stream().anyMatch(r -> !Arrays.asList(0, 1, 2).contains(r.getBlock())))
+            return new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING,
+                    "Method 0 must have block 0, 1 or 2",
+                    method0Rows.stream().map(r -> r.getId()).collect(Collectors.toList()), Arrays.asList("block"));
+
+        // VALIDATION: Both M1, M2 present and if ATRC has M3 and at least one method of
+        // 3,4,5,7
+        var requiredMethods = validation == ProgramValidation.ATRC ? Arrays.asList(1, 2, 3) : Arrays.asList(1, 2);
+        var missingMethods = new ArrayList<Integer>(requiredMethods);
+        missingMethods.removeAll(surveyByMethod.keySet());
+        if (missingMethods.size() > 0) {
+            var missingMethodsList = missingMethods.stream().map(m -> m.toString()).collect(Collectors.toList());
+            messages.add("missing M" + String.join(", M", missingMethodsList));
+            rowIds.addAll(surveyRows.stream().map(r -> r.getId()).collect(Collectors.toList()));
+            flagColumns.add("method");
+        }
+
+        // VALIDATION: M1, M2 each has B1, B2 and if ATRC M3 has B0
+        var methodsRequired = validation == ProgramValidation.RLS ? Arrays.asList(1, 2) : Arrays.asList(1, 2, 3);
+        var level = ValidationLevel.WARNING;
+        for (var method : methodsRequired) {
+            var methodRows = surveyByMethod.get(method);
+            if (methodRows == null)
+                continue;
+
+            var blocksRequired = validation == ProgramValidation.RLS ? new ArrayList<Integer>(Arrays.asList(1, 2))
+                    : new ArrayList<Integer>(method == 3 ? Arrays.asList(0) : Arrays.asList(1, 2));
+
+            var hasBlocks = methodRows.stream().map(r -> r.getBlock()).distinct().collect(Collectors.toList());
+            var missingBlocks = blocksRequired.stream().filter(b -> !hasBlocks.contains(b))
+                    .collect(Collectors.toList());
+
+            if (missingBlocks.size() > 0) {
+                if (method == 3) {
+                    level = ValidationLevel.BLOCKING;
+                    messages.add("M3 " + (hasBlocks.size() > 0 ? "recorded on wrong block" : "missing B0"));
+                } else {
+                    messages.add("M" + method + " missing B" + String.join(", ",
+                            missingBlocks.stream().map(m -> m.toString()).collect(Collectors.toList())));
+                }
+                rowIds.addAll(methodRows.stream().map(r -> r.getId()).collect(Collectors.toList()));
+                flagColumns.add("block");
+            }
+        }
+
+        if (messages.size() > 0) {
+            return new SurveyValidationError(ValidationCategory.SPAN, level,
+                    messagePrefix + " " + String.join(". ", messages), rowIds, flagColumns);
+        }
+
+        return null;
+    }
+
+    public SurveyValidationError validateSurveyGroup(List<StagedRowFormatted> surveyRows) {
+        var surveyGroup = surveyRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurveyNum));
+        if (!surveyGroup.keySet().containsAll(Arrays.asList(1, 2, 3, 4))) {
+            var missingSurveys = new ArrayList<Integer>(Arrays.asList(1, 2, 3, 4));
+            missingSurveys.removeAll(surveyGroup.keySet());
+            var missingSurveysMessage = missingSurveys.stream().map(s -> s.toString()).collect(Collectors.toList());
+            var row = surveyRows.get(0).getRef();
+            var message = "Survey group " + row.getSurveyGroup() + " missing transect "
+                    + String.join(", ", missingSurveysMessage);
+            return new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING, message,
+                    surveyRows.stream().map(r -> r.getId()).collect(Collectors.toList()), Arrays.asList("depth"));
+        }
+        return null;
+    }
+
+    private Collection<SurveyValidationError> checkSurveys(ProgramValidation validation, Boolean isExtended,
+            Map<String, List<StagedRowFormatted>> surveyMap) {
+        var res = new HashSet<SurveyValidationError>();
+
+        for (var survey : surveyMap.entrySet()) {
+            var surveyRows = survey.getValue();
+
+            if (validation == ProgramValidation.ATRC) {
+                // VALIDATION: Survey group transect number valid
+                res.add(validateSurveyTransectNumber(surveyRows));
+            }
+
+            // VALIDATION: Survey Complete
+            res.add(validateSurveyComplete(validation, surveyRows));
+
+            // VALIDATION: Is Existing Survey
+            res.add(validateSurveyIsNew(surveyRows.get(0)));
+        }
+
+        res.remove(null);
+
+        return res;
+    }
+
+    private Collection<SurveyValidationError> checkSurveyGroups(ProgramValidation validation, Boolean isExtended,
+            Map<String, List<StagedRowFormatted>> surveyGroupMap) {
+        var res = new HashSet<SurveyValidationError>();
+
+        for (var survey : surveyGroupMap.entrySet()) {
+            var surveyRows = survey.getValue();
+
+            if (validation == ProgramValidation.ATRC) {
+                // VALIDATION: Survey Group Complete
+                res.add(validateSurveyGroup(surveyRows));
+            }
+        }
+
+        res.remove(null);
+
+        return res;
+    }
+
+    private Collection<SurveyValidationError> checkMethod3Transects(Boolean isExtended,
+            Map<String, List<StagedRowFormatted>> method3SurveyMap) {
+        var res = new HashSet<SurveyValidationError>();
+        var results = new ValidationResultSet();
+
+        // Validate M3 transects
+        for (String transectName : method3SurveyMap.keySet()) {
+            res.add(validateMethod3Quadrats(transectName, method3SurveyMap.get(transectName)));
+            res.add(validateMethod3QuadratsGT50(transectName, method3SurveyMap.get(transectName)));
+            results.addAll(validateMethod3QuadratsLT50(method3SurveyMap.get(transectName)), false);
+        }
+
+        res.addAll(results.getAll());
+        res.remove(null);
+
+        return res;
+    }
+
+    private SurveyValidationError validateSurveyIsNew(StagedRowFormatted row) {
+        if (row.getDate() != null && Arrays.asList(METHODS_TO_CHECK).contains(row.getMethod())) {
+
+            var surveyDate = Date.from(row.getDate().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
+            var existingSurveys = surveyRepository.findBySiteDepthSurveyNumDate(row.getSite(), row.getDepth(),
+                    row.getSurveyNum(), surveyDate);
+
+            if (!existingSurveys.isEmpty()) {
+                var existingSurvey = existingSurveys.stream().findFirst().get();
+                var message = "Survey exists: " + existingSurvey.getSurveyId() + " includes "
+                        + row.getDecimalSurvey();
+                return new SurveyValidationError(ValidationCategory.DATA, ValidationLevel.BLOCKING, message,
+                        Arrays.asList(row.getId()), Arrays.asList("siteCode"));
+            }
+
+        }
+        return null;
+    }
+
+    public Collection<SurveyValidationError> validateSurveys(ProgramValidation validation, Boolean isExtended, Collection<StagedRowFormatted> mappedRows) {
+        var sheetErrors = new HashSet<SurveyValidationError>();
+
+        var surveyMap = mappedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurvey));
+        sheetErrors.addAll(checkSurveys(validation, isExtended, surveyMap));
+
+        var surveyGroupMap = mappedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurveyGroup));
+        sheetErrors.addAll(checkSurveyGroups(validation, isExtended, surveyGroupMap));
+
+        var method3SurveyMap = mappedRows.stream()
+                .filter(row -> row.getMethod() != null && row.getMethod().equals(3)
+                        && !row.getRef().getSpecies().equalsIgnoreCase("Survey Not Done"))
+                .collect(Collectors.groupingBy(StagedRowFormatted::getSurvey));
+        sheetErrors.addAll(checkMethod3Transects(isExtended, method3SurveyMap));
+
+        return sheetErrors;
+    }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
@@ -256,7 +256,7 @@ public class ValidationProcess {
 
         var species = speciesFormatting.getSpeciesForRows(rows);
         sheetErrors
-                .addAll(dataValidation.checkFormatting(validation, job.getIsExtendedSize(), siteCodes, species, rows));
+                .addAll(dataValidation.checkFormatting(validation, job.getIsExtendedSize(), true, siteCodes, species, rows));
         var mappedRows = speciesFormatting.formatRowsWithSpecies(rows, species);
 
         var response = generateSummary(mappedRows);

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
@@ -6,7 +6,6 @@ import java.text.Normalizer;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -15,18 +14,15 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.commons.lang3.EnumUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
+import au.org.aodn.nrmn.restapi.controller.mapping.StagedRowFormattedMapperConfig;
 import au.org.aodn.nrmn.restapi.data.model.ObservableItem;
 import au.org.aodn.nrmn.restapi.data.model.StagedJob;
 import au.org.aodn.nrmn.restapi.data.model.StagedRow;
@@ -37,15 +33,12 @@ import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
 import au.org.aodn.nrmn.restapi.data.repository.StagedRowRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SurveyRepository;
-import au.org.aodn.nrmn.restapi.controller.mapping.StagedRowFormattedMapperConfig;
-import au.org.aodn.nrmn.restapi.dto.stage.ValidationCell;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
+import au.org.aodn.nrmn.restapi.dto.stage.ValidationCell;
 import au.org.aodn.nrmn.restapi.dto.stage.ValidationResponse;
-import au.org.aodn.nrmn.restapi.enums.Directions;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.enums.ValidationCategory;
 import au.org.aodn.nrmn.restapi.enums.ValidationLevel;
-import au.org.aodn.nrmn.restapi.util.TimeUtils;
 
 @Component
 public class ValidationProcess {
@@ -69,216 +62,14 @@ public class ValidationProcess {
     SurveyRepository surveyRepository;
 
     @Autowired
+    DataValidation dataValidation;
+
+    @Autowired
     MeasurementValidation speciesMeasurement;
 
-    private static final int INVALID_INT = Integer.MIN_VALUE;
-    private static final double INVALID_DOUBLE = Double.NEGATIVE_INFINITY;
     private static final Integer[] METHODS_TO_CHECK = { 0, 1, 2, 7, 10 };
-    private static final Pattern VALID_DEPTH_SURVEY_NUM = Pattern.compile("^[0-9]+(\\.[0-9])?$");
     private static final LocalDate DATE_MIN_RLS = LocalDate.parse("2006-01-01");
     private static final LocalDate DATE_MIN_ATRC = LocalDate.parse("1991-01-01");
-
-    // VALIDATION: Rows duplicated
-    public Collection<SurveyValidationError> checkDuplicateRows(boolean includeTotal, boolean includeSpeciesCode,
-            Collection<StagedRow> rows) {
-        var mappedRows = new HashMap<String, List<Long>>();
-        var mappedSpecies = new HashMap<String, String>();
-        rows.stream().forEach(r -> {
-            String rowHash = r.getContentsHash(includeTotal, includeSpeciesCode);
-            List<Long> rowIds = mappedRows.getOrDefault(rowHash, new ArrayList<Long>());
-            rowIds.add(r.getId());
-            if (!mappedSpecies.containsKey(rowHash))
-                mappedSpecies.put(rowHash, r.getSpecies());
-            mappedRows.put(rowHash, rowIds);
-        });
-        var duplicateRows = new ArrayList<SurveyValidationError>();
-        mappedRows.forEach((r, v) -> {
-            if (v.size() > 1) {
-                List<Long> rowIds = v.stream().collect(Collectors.toList());
-                duplicateRows.add(new SurveyValidationError(null, ValidationLevel.DUPLICATE, mappedSpecies.get(r), rowIds, null));
-
-            }
-        });
-        return duplicateRows;
-    }
-
-    public Collection<SurveyValidationError> checkFormatting(ProgramValidation validation, Boolean isExtendedSize,
-            Collection<String> siteCodes, Collection<ObservableItem> species, Collection<StagedRow> rows) {
-
-        var diverNames = new ArrayList<String>();
-        for (var d : diverRepository.getAll()) {
-            diverNames.add(Normalizer.normalize(d.getFullName(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
-                    .toUpperCase());
-            diverNames.add(Normalizer.normalize(d.getInitials(), Normalizer.Form.NFD).replaceAll("[^\\p{ASCII}]", "")
-                    .toUpperCase());
-        }
-
-        var errors = new ValidationResultSet();
-
-        errors.addGlobal(checkDuplicateRows(false, true, rows));
-
-        for (var row : rows) {
-
-            var rowId = row.getId();
-
-            // Site
-            if (row.getSiteCode() == null || !siteCodes.contains(row.getSiteCode().toLowerCase()))
-                errors.add(rowId, ValidationLevel.BLOCKING, "siteCode", "Site Code does not exist");
-
-            // Diver
-            if (row.getDiver() == null || !diverNames.contains(Normalizer.normalize(row.getDiver(), Normalizer.Form.NFD)
-                    .replaceAll("[^\\p{ASCII}]", "").toUpperCase()))
-                errors.add(rowId, ValidationLevel.BLOCKING, "diver", "Diver does not exist");
-
-            // Buddies
-            var unknownBuddies = new ArrayList<String>();
-            if (StringUtils.isNotEmpty(row.getBuddy())) {
-                for (String buddyComponent : row.getBuddy().split(",")) {
-                    String buddy = buddyComponent.trim();
-                    if (!diverNames.contains(Normalizer.normalize(buddy, Normalizer.Form.NFD)
-                            .replaceAll("[^\\p{ASCII}]", "").toUpperCase()))
-                        unknownBuddies.add(buddy);
-                }
-            }
-
-            if (StringUtils.isEmpty(row.getBuddy())) {
-                errors.add(rowId, ValidationLevel.WARNING, "buddy", "Diver does not exist", 0);
-            } else if (unknownBuddies.size() == 1) {
-                errors.add(rowId, ValidationLevel.WARNING, "buddy",
-                        "Diver " + unknownBuddies.get(0) + " does not exist", 1);
-            } else if (unknownBuddies.size() > 1) {
-                errors.add(rowId, ValidationLevel.WARNING, "buddy",
-                        "Divers " + String.join(", ", unknownBuddies) + " do not exist", unknownBuddies.size());
-            }
-
-            if (StringUtils.isBlank(row.getPqs())) {
-                errors.add(rowId, ValidationLevel.WARNING, "P-Qs", "P-Qs Diver is blank");
-            } else if (!diverNames.contains(Normalizer.normalize(row.getPqs(), Normalizer.Form.NFD)
-                    .replaceAll("[^\\p{ASCII}]", "").toUpperCase())) {
-                errors.add(rowId, ValidationLevel.WARNING, "P-Qs",
-                        String.format("Diver \"%s\" does not exist", row.getPqs()));
-            }
-
-            // VALIDATION: Species are not superseded
-            if (StringUtils.isNotEmpty(row.getSpecies()) && !row.getSpecies().equalsIgnoreCase("survey not done")) {
-                Optional<ObservableItem> observableItem = species.stream()
-                        .filter(s -> row.getSpecies().equalsIgnoreCase(s.getObservableItemName())).findAny();
-                if (observableItem.isPresent()) {
-                    String supersededBy = observableItem.get().getSupersededBy();
-                    if (StringUtils.isNotEmpty(supersededBy))
-                        errors.add(rowId, ValidationLevel.WARNING, "species", "Superseded by " + supersededBy);
-                } else {
-                    errors.add(rowId, ValidationLevel.BLOCKING, "species", "Species does not exist");
-                }
-            }
-
-            // Direction
-            if (StringUtils.isNotEmpty(row.getDirection())
-                    && !EnumUtils.isValidEnumIgnoreCase(Directions.class, row.getDirection())
-                    && !Arrays.asList("0", "").contains(row.getDirection()))
-                errors.add(rowId, ValidationLevel.BLOCKING, "direction", "Direction is not valid");
-
-            // Latitude
-            var latitude = NumberUtils.toDouble(row.getLatitude(), INVALID_DOUBLE);
-            if (latitude < -90.0 || 90.0 < latitude || latitude == INVALID_DOUBLE)
-                errors.add(rowId, ValidationLevel.BLOCKING, "latitude",
-                        (latitude == INVALID_DOUBLE) ? "Latitude is not number" : "Latitude is out of bounds");
-
-            // Longitude
-            var longitude = NumberUtils.toDouble(row.getLongitude(), INVALID_DOUBLE);
-            if (longitude < -180 || 180 < longitude || longitude == INVALID_DOUBLE)
-                errors.add(rowId, ValidationLevel.BLOCKING, "longitude",
-                        (latitude == INVALID_DOUBLE) ? "Longitude is not number" : "Longitude is out of bounds");
-
-            // Date
-            try {
-                LocalDate.parse(row.getDate(), TimeUtils.getRowDateFormatter());
-            } catch (DateTimeParseException e) {
-                errors.add(rowId, ValidationLevel.BLOCKING, "date", "Date format is not valid");
-            }
-
-            // Time
-            if (row.getTime().length() > 0 && !TimeUtils.parseTime(row.getTime()).isPresent())
-                errors.add(rowId, ValidationLevel.WARNING, "time", "Time format is not valid");
-
-            // Block
-            if (!Arrays.asList(0, 1, 2).contains(NumberUtils.toInt(row.getBlock(), INVALID_INT))) {
-                errors.add(rowId, ValidationLevel.BLOCKING, "block", "Block must be 0, 1 or 2");
-            }
-
-            // Vis
-            if (!StringUtils.isBlank(row.getVis())) {
-                Double vis = NumberUtils.toDouble(row.getVis(), (double) INVALID_INT);
-                if (vis < 0) {
-                    errors.add(rowId, ValidationLevel.BLOCKING, "vis",
-                            (vis == (double) INVALID_INT) ? "Vis is not a decimal" : "Vis is not positive");
-                } else {
-                    if (vis.toString().split("\\.")[1].length() > 1)
-                        errors.add(rowId, ValidationLevel.BLOCKING, "vis", "Vis is more than one decimal place");
-                }
-            }
-
-            // Inverts
-            var inverts = NumberUtils.toInt(row.getInverts(), INVALID_INT);
-            if (inverts == INVALID_INT)
-                errors.add(rowId, ValidationLevel.BLOCKING, "inverts", "Inverts is not an integer");
-
-            // Total
-            if (NumberUtils.toInt(row.getTotal(), INVALID_INT) == INVALID_INT)
-                errors.add(rowId, ValidationLevel.BLOCKING, "total", "Total is not an integer");
-
-            // Method
-            if (NumberUtils.toInt(row.getMethod(), INVALID_INT) == INVALID_INT)
-                errors.add(rowId, ValidationLevel.BLOCKING, "method", "Method is not an integer");
-
-            // MeasureJson
-            if (row.getMeasureJson() != null)
-                row.getMeasureJson().entrySet().stream().forEach(measure -> {
-                    if (!StringUtils.isBlank(measure.getValue())
-                            && NumberUtils.toInt(measure.getValue(), INVALID_INT) < 0)
-                        errors.add(rowId, ValidationLevel.BLOCKING, measure.getKey().toString(),
-                                "Measurement is not valid");
-                });
-
-            // Depth
-            if (StringUtils.isBlank(row.getDepth()) || !VALID_DEPTH_SURVEY_NUM.matcher(row.getDepth()).matches())
-                errors.add(rowId, ValidationLevel.BLOCKING, "depth", "Depth is invalid, expected: depth[.surveyNum]");
-
-            // RLS Method
-            if (validation == ProgramValidation.RLS
-                    && !Arrays.asList(0, 1, 2, 10).contains(NumberUtils.toInt(row.getMethod(), INVALID_INT)))
-                errors.add(rowId, ValidationLevel.BLOCKING, "method", "RLS Method must be 0, 1, 2 or 10");
-
-            // Block 0
-            if (row.getBlock().equalsIgnoreCase("0")
-                    && !Arrays.asList(0, 3, 4, 5).contains(NumberUtils.toInt(row.getMethod(), INVALID_INT)))
-                errors.add(rowId, ValidationLevel.BLOCKING, "block", "Block 0 is invalid for method");
-
-            // ATRC Method
-            if (validation == ProgramValidation.ATRC) {
-                if (!Arrays.asList(0, 1, 2, 3, 4, 5, 7, 10).contains(NumberUtils.toInt(row.getMethod(), INVALID_INT)))
-                    errors.add(rowId, ValidationLevel.BLOCKING, "method", "ATRC Method must be [0-5], 7 or 10");
-
-                if (NumberUtils.toInt(row.getMethod()) == 7 && NumberUtils.toInt(row.getBlock()) != 2)
-                    errors.add(rowId, ValidationLevel.BLOCKING, "method", "ATRC Method 7 must be recorded on block 2");
-            }
-
-            // Validation: Use Invert Sizing is blank
-            if (isExtendedSize && StringUtils.isBlank(row.getIsInvertSizing())) {
-                errors.add(rowId, ValidationLevel.WARNING, "isInvertSizing", "Use Invert Sizing is blank");
-            }
-
-            // Validation: Species Invert Sizing
-            if (isExtendedSize && !StringUtils.isBlank(row.getIsInvertSizing()) &&
-                    !(row.getIsInvertSizing().equalsIgnoreCase("YES")
-                            || row.getIsInvertSizing().equalsIgnoreCase("NO")))
-                errors.add(rowId, ValidationLevel.BLOCKING, "isInvertSizing",
-                        "Use Invert Sizing must be 'Yes' or 'No'");
-
-        }
-
-        return errors.getAll();
-    }
 
     private ValidationCell validateSpeciesBelowToMethod(StagedRowFormatted row) {
 
@@ -431,14 +222,14 @@ public class ValidationProcess {
         var flagColumns = new HashSet<String>();
         var messages = new ArrayList<String>();
 
-        // VALIDATE: If method = 0 then Block should be 0, 1 or 2
+        // VALIDATION: If method = 0 then Block should be 0, 1 or 2
         var method0Rows = surveyByMethod.get(0);
         if (method0Rows != null && method0Rows.stream().anyMatch(r -> !Arrays.asList(0, 1, 2).contains(r.getBlock())))
             return new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING,
                     "Method 0 must have block 0, 1 or 2",
                     method0Rows.stream().map(r -> r.getId()).collect(Collectors.toList()), Arrays.asList("block"));
 
-        // VALIDATE: Both M1, M2 present and if ATRC has M3 and at least one method of
+        // VALIDATION: Both M1, M2 present and if ATRC has M3 and at least one method of
         // 3,4,5,7
         var requiredMethods = validation == ProgramValidation.ATRC ? Arrays.asList(1, 2, 3) : Arrays.asList(1, 2);
         var missingMethods = new ArrayList<Integer>(requiredMethods);
@@ -450,7 +241,7 @@ public class ValidationProcess {
             flagColumns.add("method");
         }
 
-        // VALIDATE: M1, M2 each has B1, B2 and if ATRC M3 has B0
+        // VALIDATION: M1, M2 each has B1, B2 and if ATRC M3 has B0
         var methodsRequired = validation == ProgramValidation.RLS ? Arrays.asList(1, 2) : Arrays.asList(1, 2, 3);
         var level = ValidationLevel.WARNING;
         for (var method : methodsRequired) {
@@ -509,14 +300,14 @@ public class ValidationProcess {
             var surveyRows = survey.getValue();
 
             if (validation == ProgramValidation.ATRC) {
-                // VALIDATE: Survey group transect number valid
+                // VALIDATION: Survey group transect number valid
                 res.add(validateSurveyTransectNumber(surveyRows));
             }
 
-            // VALIDATE: Survey Complete
+            // VALIDATION: Survey Complete
             res.add(validateSurveyComplete(validation, surveyRows));
 
-            // VALIDATE: Is Existing Survey
+            // VALIDATION: Is Existing Survey
             res.add(validateSurveyIsNew(surveyRows.get(0)));
         }
 
@@ -533,7 +324,7 @@ public class ValidationProcess {
             var surveyRows = survey.getValue();
 
             if (validation == ProgramValidation.ATRC) {
-                // VALIDATE: Survey Group Complete
+                // VALIDATION: Survey Group Complete
                 res.add(validateSurveyGroup(surveyRows));
             }
         }
@@ -703,7 +494,7 @@ public class ValidationProcess {
         var siteCodes = siteRepository.getAllSiteCodesMatching(enteredSiteCodes);
         var sheetErrors = new HashSet<SurveyValidationError>();
 
-        sheetErrors.addAll(checkFormatting(validation, job.getIsExtendedSize(), siteCodes, species, rows));
+        sheetErrors.addAll(dataValidation.checkFormatting(validation, job.getIsExtendedSize(), siteCodes, species, rows));
 
         var mappedRows = formatRowsWithSpecies(rows, species);
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
@@ -269,6 +269,8 @@ public class ValidationProcess {
         sheetErrors.addAll(checkData(validation, job.getIsExtendedSize(), mappedRows));
 
         sheetErrors.addAll(surveyValidation.validateSurveys(validation, job.getIsExtendedSize(), mappedRows));
+        
+        sheetErrors.addAll(surveyValidation.validateSurveyGroups(validation, job.getIsExtendedSize(), mappedRows));
 
         response.setIncompleteSurveyCount(sheetErrors.stream().filter(e -> e.getMessage().contains("Survey incomplete")).count());
         response.setExistingSurveyCount(sheetErrors.stream().filter(e -> e.getMessage().contains("Survey exists:")).count());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
@@ -4,16 +4,12 @@ import static au.org.aodn.nrmn.restapi.util.SpacialUtil.getDistanceLatLongMeters
 
 import java.text.Normalizer;
 import java.time.LocalDate;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -67,7 +63,9 @@ public class ValidationProcess {
     @Autowired
     SpeciesFormattingService speciesFormatting;
 
-    private static final Integer[] METHODS_TO_CHECK = { 0, 1, 2, 7, 10 };
+    @Autowired
+    SurveyValidation surveyValidation;
+
     private static final LocalDate DATE_MIN_RLS = LocalDate.parse("2006-01-01");
     private static final LocalDate DATE_MIN_ATRC = LocalDate.parse("1991-01-01");
 
@@ -82,33 +80,6 @@ public class ValidationProcess {
                         ValidationCategory.DATA, ValidationLevel.WARNING, "Method " + row.getMethod()
                                 + " invalid for species " + row.getSpecies().get().getObservableItemName(),
                         row.getId(), "method");
-
-        }
-        return null;
-    }
-
-    private ValidationCell validateInvertsZeroOnM3M4M5(StagedRowFormatted row) {
-        return (row.getMethod() != null && row.getInverts() != null && Arrays.asList(3, 4, 5).contains(row.getMethod())
-                && row.getInverts() > 0)
-                        ? new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING,
-                                "Method " + row.getMethod() + " has value for inverts", row.getId(), "inverts")
-                        : null;
-    }
-
-    private SurveyValidationError validateSurveyIsNew(StagedRowFormatted row) {
-        if (row.getDate() != null && Arrays.asList(METHODS_TO_CHECK).contains(row.getMethod())) {
-
-            var surveyDate = Date.from(row.getDate().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant());
-            var existingSurveys = surveyRepository.findBySiteDepthSurveyNumDate(row.getSite(), row.getDepth(),
-                    row.getSurveyNum(), surveyDate);
-
-            if (!existingSurveys.isEmpty()) {
-                var existingSurvey = existingSurveys.stream().findFirst().get();
-                var message = "Survey exists: " + existingSurvey.getSurveyId() + " includes "
-                        + row.getDecimalSurvey();
-                return new SurveyValidationError(ValidationCategory.DATA, ValidationLevel.BLOCKING, message,
-                        Arrays.asList(row.getId()), Arrays.asList("siteCode"));
-            }
 
         }
         return null;
@@ -137,219 +108,12 @@ public class ValidationProcess {
         return errors;
     }
 
-    private ValidationCell validateDateRange(LocalDate earliest, StagedRowFormatted row) {
-
-        if (row.getDate() == null)
-            return null;
-
-        // Validation: Surveys Too Old
-        if (row.getDate().isAfter(LocalDate.from(ZonedDateTime.now())))
-            return new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING, "Date is in the future",
-                    row.getId(), "date");
-
-        // Validation: Future Survey Rule
-        if (row.getDate().isBefore(earliest))
-            return new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING,
-                    "Date must be after " + earliest.toString(), row.getId(), "date");
-
-        return null;
-    }
-
-    public SurveyValidationError validateMethod3Quadrats(String transect, List<StagedRowFormatted> rows) {
-
-        var columnNames = new HashSet<String>();
-        var rowIds = new HashSet<Long>();
-
-        for (int measureIndex : Arrays.asList(1, 2, 3, 4, 5))
-            if (rows.stream().mapToInt(row -> row.getMeasureJson().getOrDefault(measureIndex, 0)).sum() == 0) {
-                rowIds.addAll(rows.stream().map(r -> r.getId()).collect(Collectors.toList()));
-                columnNames.add(Integer.toString(measureIndex));
-            }
-
-        return rowIds.size() > 0 ? new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.BLOCKING,
-                "Missing quadrats in transect " + transect, rowIds, columnNames) : null;
-    }
-
-    public Collection<ValidationCell> validateMethod3QuadratsLT50(List<StagedRowFormatted> rows) {
-        var errors = new ArrayList<ValidationCell>();
-
-        for (int measureIndex : Arrays.asList(1, 2, 3, 4, 5))
-            for (var row : rows) {
-                if (row.getMeasureJson().getOrDefault(measureIndex, 0) > 50)
-                    errors.add(new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING,
-                            "M3 quadrat more than 50", row.getId(), Integer.toString(measureIndex)));
-            }
-
-        return errors;
-    }
-
-    public SurveyValidationError validateMethod3QuadratsGT50(String transect, List<StagedRowFormatted> rows) {
-
-        var columnNames = new HashSet<String>();
-
-        for (var measureIndex : Arrays.asList(1, 2, 3, 4, 5)) {
-            if (rows.stream().mapToInt(row -> row.getMeasureJson().getOrDefault(measureIndex, 0)).sum() < 50)
-                columnNames.add(Integer.toString(measureIndex));
-        }
-
-        var rowIds = rows.stream().map(r -> r.getId()).collect(Collectors.toList());
-        return columnNames.size() > 0 ? new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.BLOCKING,
-                "Quadrats do not sum to at least 50 in transect " + transect, rowIds, columnNames) : null;
-    }
-
-    public SurveyValidationError validateSurveyTransectNumber(List<StagedRowFormatted> surveyRows) {
-        var invalidTransectRows = surveyRows.stream()
-                .filter(r -> !Arrays.asList(1, 2, 3, 4).contains(r.getSurveyNum())).collect(Collectors.toList());
-        if (invalidTransectRows.size() > 0)
-            return new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING,
-                    "Survey group transect invalid",
-                    invalidTransectRows.stream().map(r -> r.getId()).collect(Collectors.toList()),
-                    Arrays.asList("depth"));
-        return null;
-    }
-
-    private SurveyValidationError validateSurveyComplete(ProgramValidation validation, List<StagedRowFormatted> surveyRows) {
-
-        if (surveyRows.stream().anyMatch(r -> r.getMethod() == null || r.getBlock() == null))
-            return null;
-
-        var messagePrefix = "Survey incomplete: " + surveyRows.get(0).getDecimalSurvey();
-
-        var surveyByMethod = surveyRows.stream().filter(sr -> sr.getMethod() != null && sr.getBlock() != null)
-                .collect(Collectors.groupingBy(StagedRowFormatted::getMethod));
-
-        var rowIds = new HashSet<Long>();
-        var flagColumns = new HashSet<String>();
-        var messages = new ArrayList<String>();
-
-        // VALIDATION: If method = 0 then Block should be 0, 1 or 2
-        var method0Rows = surveyByMethod.get(0);
-        if (method0Rows != null && method0Rows.stream().anyMatch(r -> !Arrays.asList(0, 1, 2).contains(r.getBlock())))
-            return new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING,
-                    "Method 0 must have block 0, 1 or 2",
-                    method0Rows.stream().map(r -> r.getId()).collect(Collectors.toList()), Arrays.asList("block"));
-
-        // VALIDATION: Both M1, M2 present and if ATRC has M3 and at least one method of
-        // 3,4,5,7
-        var requiredMethods = validation == ProgramValidation.ATRC ? Arrays.asList(1, 2, 3) : Arrays.asList(1, 2);
-        var missingMethods = new ArrayList<Integer>(requiredMethods);
-        missingMethods.removeAll(surveyByMethod.keySet());
-        if (missingMethods.size() > 0) {
-            var missingMethodsList = missingMethods.stream().map(m -> m.toString()).collect(Collectors.toList());
-            messages.add("missing M" + String.join(", M", missingMethodsList));
-            rowIds.addAll(surveyRows.stream().map(r -> r.getId()).collect(Collectors.toList()));
-            flagColumns.add("method");
-        }
-
-        // VALIDATION: M1, M2 each has B1, B2 and if ATRC M3 has B0
-        var methodsRequired = validation == ProgramValidation.RLS ? Arrays.asList(1, 2) : Arrays.asList(1, 2, 3);
-        var level = ValidationLevel.WARNING;
-        for (var method : methodsRequired) {
-            var methodRows = surveyByMethod.get(method);
-            if (methodRows == null)
-                continue;
-
-            var blocksRequired = validation == ProgramValidation.RLS ? new ArrayList<Integer>(Arrays.asList(1, 2))
-                    : new ArrayList<Integer>(method == 3 ? Arrays.asList(0) : Arrays.asList(1, 2));
-
-            var hasBlocks = methodRows.stream().map(r -> r.getBlock()).distinct().collect(Collectors.toList());
-            var missingBlocks = blocksRequired.stream().filter(b -> !hasBlocks.contains(b))
-                    .collect(Collectors.toList());
-
-            if (missingBlocks.size() > 0) {
-                if (method == 3) {
-                    level = ValidationLevel.BLOCKING;
-                    messages.add("M3 " + (hasBlocks.size() > 0 ? "recorded on wrong block" : "missing B0"));
-                } else {
-                    messages.add("M" + method + " missing B" + String.join(", ",
-                            missingBlocks.stream().map(m -> m.toString()).collect(Collectors.toList())));
-                }
-                rowIds.addAll(methodRows.stream().map(r -> r.getId()).collect(Collectors.toList()));
-                flagColumns.add("block");
-            }
-        }
-
-        if (messages.size() > 0) {
-            return new SurveyValidationError(ValidationCategory.SPAN, level,
-                    messagePrefix + " " + String.join(". ", messages), rowIds, flagColumns);
-        }
-
-        return null;
-    }
-
-    public SurveyValidationError validateSurveyGroup(List<StagedRowFormatted> surveyRows) {
-        var surveyGroup = surveyRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurveyNum));
-        if (!surveyGroup.keySet().containsAll(Arrays.asList(1, 2, 3, 4))) {
-            var missingSurveys = new ArrayList<Integer>(Arrays.asList(1, 2, 3, 4));
-            missingSurveys.removeAll(surveyGroup.keySet());
-            var missingSurveysMessage = missingSurveys.stream().map(s -> s.toString()).collect(Collectors.toList());
-            var row = surveyRows.get(0).getRef();
-            var message = "Survey group " + row.getSurveyGroup() + " missing transect "
-                    + String.join(", ", missingSurveysMessage);
-            return new SurveyValidationError(ValidationCategory.SPAN, ValidationLevel.WARNING, message,
-                    surveyRows.stream().map(r -> r.getId()).collect(Collectors.toList()), Arrays.asList("depth"));
-        }
-        return null;
-    }
-
-    private Collection<SurveyValidationError> checkSurveys(ProgramValidation validation, Boolean isExtended,
-            Map<String, List<StagedRowFormatted>> surveyMap) {
-        var res = new HashSet<SurveyValidationError>();
-
-        for (var survey : surveyMap.entrySet()) {
-            var surveyRows = survey.getValue();
-
-            if (validation == ProgramValidation.ATRC) {
-                // VALIDATION: Survey group transect number valid
-                res.add(validateSurveyTransectNumber(surveyRows));
-            }
-
-            // VALIDATION: Survey Complete
-            res.add(validateSurveyComplete(validation, surveyRows));
-
-            // VALIDATION: Is Existing Survey
-            res.add(validateSurveyIsNew(surveyRows.get(0)));
-        }
-
-        res.remove(null);
-
-        return res;
-    }
-
-    private Collection<SurveyValidationError> checkSurveyGroups(ProgramValidation validation, Boolean isExtended,
-            Map<String, List<StagedRowFormatted>> surveyGroupMap) {
-        var res = new HashSet<SurveyValidationError>();
-
-        for (var survey : surveyGroupMap.entrySet()) {
-            var surveyRows = survey.getValue();
-
-            if (validation == ProgramValidation.ATRC) {
-                // VALIDATION: Survey Group Complete
-                res.add(validateSurveyGroup(surveyRows));
-            }
-        }
-
-        res.remove(null);
-
-        return res;
-    }
-
-    private Collection<SurveyValidationError> checkMethod3Transects(Boolean isExtended,
-            Map<String, List<StagedRowFormatted>> method3SurveyMap) {
-        var res = new HashSet<SurveyValidationError>();
-        var results = new ValidationResultSet();
-
-        // Validate M3 transects
-        for (String transectName : method3SurveyMap.keySet()) {
-            res.add(validateMethod3Quadrats(transectName, method3SurveyMap.get(transectName)));
-            res.add(validateMethod3QuadratsGT50(transectName, method3SurveyMap.get(transectName)));
-            results.addAll(validateMethod3QuadratsLT50(method3SurveyMap.get(transectName)), false);
-        }
-
-        res.addAll(results.getAll());
-        res.remove(null);
-
-        return res;
+    private ValidationCell validateInvertsZeroOnM3M4M5(StagedRowFormatted row) {
+        return (row.getMethod() != null && row.getInverts() != null && Arrays.asList(3, 4, 5).contains(row.getMethod())
+                && row.getInverts() > 0)
+                        ? new ValidationCell(ValidationCategory.DATA, ValidationLevel.BLOCKING,
+                                "Method " + row.getMethod() + " has value for inverts", row.getId(), "inverts")
+                        : null;
     }
 
     public Collection<SurveyValidationError> checkData(ProgramValidation validation, Boolean isExtended,
@@ -387,6 +151,24 @@ public class ValidationProcess {
         res.addAll(results.getAll());
         res.remove(null);
         return res;
+    }
+
+    private ValidationCell validateDateRange(LocalDate earliest, StagedRowFormatted row) {
+
+        if (row.getDate() == null)
+            return null;
+
+        // Validation: Surveys Too Old
+        if (row.getDate().isAfter(LocalDate.from(ZonedDateTime.now())))
+            return new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING, "Date is in the future",
+                    row.getId(), "date");
+
+        // Validation: Future Survey Rule
+        if (row.getDate().isBefore(earliest))
+            return new ValidationCell(ValidationCategory.DATA, ValidationLevel.WARNING,
+                    "Date must be after " + earliest.toString(), row.getId(), "date");
+
+        return null;
     }
 
     public ValidationResponse generateSummary(Collection<StagedRowFormatted> mappedRows) {
@@ -473,7 +255,8 @@ public class ValidationProcess {
         var sheetErrors = new HashSet<SurveyValidationError>();
 
         var species = speciesFormatting.getSpeciesForRows(rows);
-        sheetErrors.addAll(dataValidation.checkFormatting(validation, job.getIsExtendedSize(), siteCodes, species, rows));
+        sheetErrors
+                .addAll(dataValidation.checkFormatting(validation, job.getIsExtendedSize(), siteCodes, species, rows));
         var mappedRows = speciesFormatting.formatRowsWithSpecies(rows, species);
 
         var response = generateSummary(mappedRows);
@@ -485,21 +268,10 @@ public class ValidationProcess {
 
         sheetErrors.addAll(checkData(validation, job.getIsExtendedSize(), mappedRows));
 
-        var surveyMap = mappedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurvey));
-        sheetErrors.addAll(checkSurveys(validation, job.getIsExtendedSize(), surveyMap));
-        response.setIncompleteSurveyCount(
-                sheetErrors.stream().filter(e -> e.getMessage().contains("Survey incomplete")).count());
-        response.setExistingSurveyCount(
-                sheetErrors.stream().filter(e -> e.getMessage().contains("Survey exists:")).count());
+        sheetErrors.addAll(surveyValidation.validateSurveys(validation, job.getIsExtendedSize(), mappedRows));
 
-        var surveyGroupMap = mappedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurveyGroup));
-        sheetErrors.addAll(checkSurveyGroups(validation, job.getIsExtendedSize(), surveyGroupMap));
-
-        var method3SurveyMap = mappedRows.stream()
-                .filter(row -> row.getMethod() != null && row.getMethod().equals(3)
-                        && !row.getRef().getSpecies().equalsIgnoreCase("Survey Not Done"))
-                .collect(Collectors.groupingBy(StagedRowFormatted::getSurvey));
-        sheetErrors.addAll(checkMethod3Transects(job.getIsExtendedSize(), method3SurveyMap));
+        response.setIncompleteSurveyCount(sheetErrors.stream().filter(e -> e.getMessage().contains("Survey incomplete")).count());
+        response.setExistingSurveyCount(sheetErrors.stream().filter(e -> e.getMessage().contains("Survey exists:")).count());
 
         var distinctSurveys = mappedRows.stream().filter(r -> Arrays.asList(1, 2).contains(r.getMethod()))
                 .map(r -> r.getSurvey()).distinct().count();

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationResultSet.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationResultSet.java
@@ -17,28 +17,29 @@ public class ValidationResultSet {
 
     Map<String, SurveyValidationError> errorMap = new HashMap<String, SurveyValidationError>();
 
-    public void addGlobal(Collection<SurveyValidationError> validationRows) {
+    public void add(SurveyValidationError validationRow) {
+        if(validationRow == null) return;
+        var validationRowKey = validationRow.getMessage();
+        SurveyValidationError value = errorMap.getOrDefault(validationRowKey, new SurveyValidationError(ValidationCategory.DATA, validationRow.getLevelId(), validationRow.getMessage(), validationRow.getRowIds(), null));
+        if (value != null) {
+            var rowIds = Stream.concat(value.getRowIds().stream(), validationRow.getRowIds().stream());
+            value.setRowIds(rowIds.distinct().collect(Collectors.toList()));
+            value.setRowIds(value.getRowIds().stream().distinct().collect(Collectors.toList()));
+        }
+        errorMap.put(validationRowKey, value);
+    }
+
+    public void addAll(Collection<SurveyValidationError> validationRows) {
         for (SurveyValidationError validationRow : validationRows) {
-            var validationRowKey = validationRow.getMessage();
-            SurveyValidationError value = errorMap.getOrDefault(validationRowKey, new SurveyValidationError(ValidationCategory.DATA, validationRow.getLevelId(), validationRow.getMessage(), validationRow.getRowIds(), null));
-            if (value != null) {
-                var rowIds = Stream.concat(value.getRowIds().stream(), validationRow.getRowIds().stream());
-                value.setRowIds(rowIds.distinct().collect(Collectors.toList()));
-                value.setRowIds(value.getRowIds().stream().distinct().collect(Collectors.toList()));
-            }
-            errorMap.put(validationRowKey, value);
+            add(validationRow);
         }
     }
 
     public void add(Long id, ValidationLevel validationLevel, String column, String message) {
-        add(id, ValidationCategory.DATA, validationLevel, column, message, false, 1);
+        add(id, ValidationCategory.DATA, validationLevel, column, message, false);
     }
 
-    public void add(Long id, ValidationLevel validationLevel, String column, String message, Integer count) {
-        add(id, ValidationCategory.DATA, validationLevel, column, message, false, count);
-    }
-
-    private void add(Long id, ValidationCategory validationCategory, ValidationLevel validationLevel, String column, String message, Boolean groupInRow, Integer count) {
+    private void add(Long id, ValidationCategory validationCategory, ValidationLevel validationLevel, String column, String message, Boolean groupInRow) {
         String key = (groupInRow) ? message + Long.toString(id) : message + column;
         SurveyValidationError defaultValue = new SurveyValidationError(validationCategory, validationLevel, message, new HashSet<>(Arrays.asList(id)), new HashSet<>(Arrays.asList(column)));
         SurveyValidationError value = errorMap.getOrDefault(key, defaultValue);
@@ -51,12 +52,12 @@ public class ValidationResultSet {
 
     public void add(ValidationCell cell, Boolean groupInRow) {
         if (cell != null)
-            add(cell.getRowId(), cell.getCategoryId(), cell.getLevelId(), cell.getColumnName(), cell.getMessage(), groupInRow, 1);
+            add(cell.getRowId(), cell.getCategoryId(), cell.getLevelId(), cell.getColumnName(), cell.getMessage(), groupInRow);
     }
 
     public void addAll(Collection<ValidationCell> cells, Boolean groupInRow) {
         for (ValidationCell cell : cells) {
-            add(cell.getRowId(), cell.getCategoryId(), cell.getLevelId(), cell.getColumnName(), cell.getMessage(), groupInRow, 1);
+            add(cell.getRowId(), cell.getCategoryId(), cell.getLevelId(), cell.getColumnName(), cell.getMessage(), groupInRow);
         }
     }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationResultSet.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationResultSet.java
@@ -20,7 +20,7 @@ public class ValidationResultSet {
     public void add(SurveyValidationError validationRow) {
         if(validationRow == null) return;
         var validationRowKey = validationRow.getMessage();
-        SurveyValidationError value = errorMap.getOrDefault(validationRowKey, new SurveyValidationError(ValidationCategory.DATA, validationRow.getLevelId(), validationRow.getMessage(), validationRow.getRowIds(), null));
+        var value = errorMap.getOrDefault(validationRowKey, new SurveyValidationError(ValidationCategory.DATA, validationRow.getLevelId(), validationRow.getMessage(), validationRow.getRowIds(), validationRow.getColumnNames()));
         if (value != null) {
             var rowIds = Stream.concat(value.getRowIds().stream(), validationRow.getRowIds().stream());
             value.setRowIds(rowIds.distinct().collect(Collectors.toList()));
@@ -40,9 +40,9 @@ public class ValidationResultSet {
     }
 
     private void add(Long id, ValidationCategory validationCategory, ValidationLevel validationLevel, String column, String message, Boolean groupInRow) {
-        String key = (groupInRow) ? message + Long.toString(id) : message + column;
-        SurveyValidationError defaultValue = new SurveyValidationError(validationCategory, validationLevel, message, new HashSet<>(Arrays.asList(id)), new HashSet<>(Arrays.asList(column)));
-        SurveyValidationError value = errorMap.getOrDefault(key, defaultValue);
+        var key = (groupInRow) ? message + Long.toString(id) : message + column;
+        var defaultValue = new SurveyValidationError(validationCategory, validationLevel, message, new HashSet<>(Arrays.asList(id)), new HashSet<>(Arrays.asList(column)));
+        var value = errorMap.getOrDefault(key, defaultValue);
         if (value != null) {
             value.getRowIds().add(id);
             value.getColumnNames().add(column);

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationResultSet.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationResultSet.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import au.org.aodn.nrmn.restapi.dto.stage.ValidationCell;
 import au.org.aodn.nrmn.restapi.enums.ValidationCategory;
@@ -20,10 +21,10 @@ public class ValidationResultSet {
         for (SurveyValidationError validationRow : validationRows) {
             SurveyValidationError value = errorMap.getOrDefault(validationRow.getMessage(), new SurveyValidationError(ValidationCategory.DATA, validationRow.getLevelId(), validationRow.getMessage(), validationRow.getRowIds(), null));
             if (value != null) {
-                value.getRowIds().addAll(validationRow.getRowIds());
-                value.setRowIds(value.getRowIds().stream().distinct().collect(Collectors.toList()));
+                var rowIds = Stream.concat(value.getRowIds().stream(), validationRow.getRowIds().stream());
+                value.setRowIds(rowIds.distinct().collect(Collectors.toList()));
             }
-            errorMap.put(Long.toString(validationRow.getId()), value);
+            errorMap.put(value.getRowIds().stream().map(id -> id.toString()).collect(Collectors.joining(".")) + value.getMessage(), value);
         }
     }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationResultSet.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationResultSet.java
@@ -19,12 +19,14 @@ public class ValidationResultSet {
 
     public void addGlobal(Collection<SurveyValidationError> validationRows) {
         for (SurveyValidationError validationRow : validationRows) {
-            SurveyValidationError value = errorMap.getOrDefault(validationRow.getMessage(), new SurveyValidationError(ValidationCategory.DATA, validationRow.getLevelId(), validationRow.getMessage(), validationRow.getRowIds(), null));
+            var validationRowKey = validationRow.getMessage();
+            SurveyValidationError value = errorMap.getOrDefault(validationRowKey, new SurveyValidationError(ValidationCategory.DATA, validationRow.getLevelId(), validationRow.getMessage(), validationRow.getRowIds(), null));
             if (value != null) {
                 var rowIds = Stream.concat(value.getRowIds().stream(), validationRow.getRowIds().stream());
                 value.setRowIds(rowIds.distinct().collect(Collectors.toList()));
+                value.setRowIds(value.getRowIds().stream().distinct().collect(Collectors.toList()));
             }
-            errorMap.put(value.getRowIds().stream().map(id -> id.toString()).collect(Collectors.joining(".")) + value.getMessage(), value);
+            errorMap.put(validationRowKey, value);
         }
     }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/util/ObjectUtils.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/util/ObjectUtils.java
@@ -13,7 +13,7 @@ public class ObjectUtils {
         var contentEmpty = !contentDiffers && StringUtils.isEmpty(valueA);
         var valueDiffers = StringUtils.isNotEmpty(valueA)
                 && StringUtils.isNotEmpty(valueB)
-                && !valueA.equalsIgnoreCase(valueB);
+                && (valueA != null && !valueA.equalsIgnoreCase(valueB));
         return contentDiffers || valueDiffers || contentEmpty;
     }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/util/SpacialUtil.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/util/SpacialUtil.java
@@ -3,13 +3,25 @@ package au.org.aodn.nrmn.restapi.util;
 public class SpacialUtil {
 
     // Haversine formula. See: http://www.movable-type.co.uk/scripts/latlong.html
-    public static double getDistanceLatLongMeters(double lat1, double lon1, double lat2, double lon2) {
-        double earthRadius = 6371000; //meters
-        double dLat = Math.toRadians(lat2-lat1);
-        double dLon = Math.toRadians(lon2-lon1);
-        double a = Math.sin(dLat/2) * Math.sin(dLat/2) +Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) * Math.sin(dLon/2) * Math.sin(dLon/2);
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
-        double dist = earthRadius * c;
-        return dist;
+    public static double getDistanceLatLongMeters(Double latitude1, Double longitude1, Double latitude2, Double longitude2) {
+
+        try
+        {
+            double lat1 = latitude1;
+            double lat2 = latitude2;
+            double lon1 = longitude1;
+            double lon2 = longitude2;
+
+            double earthRadius = 6371000; //meters
+            double dLat = Math.toRadians(lat2-lat1);
+            double dLon = Math.toRadians(lon2-lon1);
+            double a = Math.sin(dLat/2) * Math.sin(dLat/2) +Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) * Math.sin(dLon/2) * Math.sin(dLon/2);
+            double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+            double dist = earthRadius * c;
+            return dist;
+
+        } catch(NullPointerException ex) {
+            return 0;
+        }
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/controller/AuthControllerIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/controller/AuthControllerIT.java
@@ -24,6 +24,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 import static io.restassured.RestAssured.given;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @Testcontainers
 @SpringBootTest(classes = RestApiApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -43,12 +44,12 @@ public class AuthControllerIT {
         ResponseEntity<JwtAuthenticationResponse> response = loginResponse("auth@example.com", "Hnh3?gx5zE*f7TVF5tKq");
 
         assertEquals(response.getStatusCode(), HttpStatus.OK);
-        assertEquals(response.getBody().getAccessToken().length() > 10, true);
-        assertEquals(response.getBody().getTokenType(), "Bearer");
+        var body = response.getBody();
+        assertNotNull(body);
+        assertEquals(body.getAccessToken().length() > 10, true);
+        assertEquals(body.getTokenType(), "Bearer");
 
-        String token = response.getBody().getAccessToken();
-
-        ResponseEntity<Void> resp = logoutResponse(token);
+        ResponseEntity<Void> resp = logoutResponse(body.getAccessToken());
         assertEquals(resp.getStatusCode(), HttpStatus.OK);
     }
 
@@ -116,8 +117,9 @@ public class AuthControllerIT {
     }
 
     private String login(String username, String password) throws Exception {
-        ResponseEntity<JwtAuthenticationResponse> response = loginResponse(username, password);
-        return response.getBody().getAccessToken();
+        var response = loginResponse(username, password);
+        var body = response.getBody();
+        return body != null ? body.getAccessToken() : "";
     }
 
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ATRCMethodCheckIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ATRCMethodCheckIT.java
@@ -15,7 +15,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.test.PostgresqlContainerExtension;
 import au.org.aodn.nrmn.restapi.test.annotations.WithTestData;
 
@@ -26,7 +26,7 @@ import au.org.aodn.nrmn.restapi.test.annotations.WithTestData;
 class ATRCMethodCheckIT {
 
     @Autowired
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @Test
     void only12methodShouldSucceed() {
@@ -51,7 +51,7 @@ class ATRCMethodCheckIT {
         StagedRow m2b1d8 = (StagedRow) SerializationUtils.clone(m1b1d8);
         m1b1d8.setMethod("2");
 
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
                 Arrays.asList(), Arrays.asList(m1b1, m2b1, m2b2, m1b1d8, m2b1d8));
 
         assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("ATRC Method must be [0-5], 7 or 10")));
@@ -83,7 +83,7 @@ class ATRCMethodCheckIT {
         StagedRow m5b3 = (StagedRow) SerializationUtils.clone(m3b1);
         m5b3.setBlock("5");
 
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
                 Arrays.asList(), Arrays.asList(m0b1, m0b2, m3b1, m3b3, m5b3));
 
         assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("ATRC Method must be [0-5], 7 or 10")));
@@ -109,7 +109,7 @@ class ATRCMethodCheckIT {
         StagedRow m2b1d8 = (StagedRow) SerializationUtils.clone(m1b1d8);
         m1b1d8.setMethod("2");
 
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
                 Arrays.asList(), Arrays.asList(m1b1, m1b1d10, m1b1d8, m2b1d8));
 
         assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("ATRC Method must be [0-5], 7 or 10")));

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ATRCMethodCheckIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ATRCMethodCheckIT.java
@@ -51,7 +51,7 @@ class ATRCMethodCheckIT {
         StagedRow m2b1d8 = (StagedRow) SerializationUtils.clone(m1b1d8);
         m1b1d8.setMethod("2");
 
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"),
                 Arrays.asList(), Arrays.asList(m1b1, m2b1, m2b2, m1b1d8, m2b1d8));
 
         assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("ATRC Method must be [0-5], 7 or 10")));
@@ -83,7 +83,7 @@ class ATRCMethodCheckIT {
         StagedRow m5b3 = (StagedRow) SerializationUtils.clone(m3b1);
         m5b3.setBlock("5");
 
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"),
                 Arrays.asList(), Arrays.asList(m0b1, m0b2, m3b1, m3b3, m5b3));
 
         assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("ATRC Method must be [0-5], 7 or 10")));
@@ -109,7 +109,7 @@ class ATRCMethodCheckIT {
         StagedRow m2b1d8 = (StagedRow) SerializationUtils.clone(m1b1d8);
         m1b1d8.setMethod("2");
 
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"),
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"),
                 Arrays.asList(), Arrays.asList(m1b1, m1b1d10, m1b1d8, m2b1d8));
 
         assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("ATRC Method must be [0-5], 7 or 10")));

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/DiverExistsIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/DiverExistsIT.java
@@ -40,7 +40,7 @@ class DiverExistsIT {
         StagedRow row = new StagedRow();
         row.setDiver("NOP");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertTrue(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Diver does not exist")));
     }
 
@@ -51,7 +51,7 @@ class DiverExistsIT {
         StagedRow row = new StagedRow();
         row.setStagedJob(job);
         row.setDiver("JEP");
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertFalse(res.stream().anyMatch(e -> e.getColumnNames().contains("diver") && e.getMessage().equalsIgnoreCase("Diver does not exist")));
     }
 
@@ -62,7 +62,7 @@ class DiverExistsIT {
         StagedRow row = new StagedRow();
         row.setStagedJob(job);
         row.setDiver("Juán Español Página");
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertFalse(res.stream().anyMatch(e -> e.getColumnNames().contains("diver") && e.getMessage().equalsIgnoreCase("Diver does not exist")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/DiverExistsIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/DiverExistsIT.java
@@ -17,7 +17,7 @@ import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.data.repository.DiverRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.test.PostgresqlContainerExtension;
 import au.org.aodn.nrmn.restapi.test.annotations.WithTestData;
 
@@ -28,7 +28,7 @@ import au.org.aodn.nrmn.restapi.test.annotations.WithTestData;
 class DiverExistsIT {
 
     @Autowired
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @Autowired
     DiverRepository diverRepo;
@@ -40,7 +40,7 @@ class DiverExistsIT {
         StagedRow row = new StagedRow();
         row.setDiver("NOP");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertTrue(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Diver does not exist")));
     }
 
@@ -51,7 +51,7 @@ class DiverExistsIT {
         StagedRow row = new StagedRow();
         row.setStagedJob(job);
         row.setDiver("JEP");
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertFalse(res.stream().anyMatch(e -> e.getColumnNames().contains("diver") && e.getMessage().equalsIgnoreCase("Diver does not exist")));
     }
 
@@ -62,7 +62,7 @@ class DiverExistsIT {
         StagedRow row = new StagedRow();
         row.setStagedJob(job);
         row.setDiver("Juán Español Página");
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertFalse(res.stream().anyMatch(e -> e.getColumnNames().contains("diver") && e.getMessage().equalsIgnoreCase("Diver does not exist")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ObservableItemExistsIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ObservableItemExistsIT.java
@@ -17,7 +17,7 @@ import au.org.aodn.nrmn.restapi.data.model.StagedJob;
 import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.test.PostgresqlContainerExtension;
 import au.org.aodn.nrmn.restapi.test.annotations.WithTestData;
 
@@ -28,7 +28,7 @@ import au.org.aodn.nrmn.restapi.test.annotations.WithTestData;
 class ObservableItemExistsIT {
 
     @Autowired
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @Test
     void notFoundSpeciesShouldFail() {
@@ -37,7 +37,7 @@ class ObservableItemExistsIT {
         StagedRow row = new StagedRow();
         row.setSpecies("Species 20");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
                 Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Species does not exist")));
     }
@@ -49,7 +49,7 @@ class ObservableItemExistsIT {
         StagedRow row = new StagedRow();
         row.setSpecies("Species 56");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
                 Arrays.asList(ObservableItem.builder().observableItemName("Species 56").build()), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Species does not exist")));
     }
@@ -61,7 +61,7 @@ class ObservableItemExistsIT {
         StagedRow row = new StagedRow();
         row.setSpecies("Survey not done");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
                 Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Species does not exist")));
     }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ObservableItemExistsIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ObservableItemExistsIT.java
@@ -37,7 +37,7 @@ class ObservableItemExistsIT {
         StagedRow row = new StagedRow();
         row.setSpecies("Species 20");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(),
                 Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Species does not exist")));
     }
@@ -49,7 +49,7 @@ class ObservableItemExistsIT {
         StagedRow row = new StagedRow();
         row.setSpecies("Species 56");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(),
                 Arrays.asList(ObservableItem.builder().observableItemName("Species 56").build()), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Species does not exist")));
     }
@@ -61,7 +61,7 @@ class ObservableItemExistsIT {
         StagedRow row = new StagedRow();
         row.setSpecies("Survey not done");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(),
                 Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Species does not exist")));
     }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/StagedRowFormattedMappingIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/StagedRowFormattedMappingIT.java
@@ -23,8 +23,8 @@ import au.org.aodn.nrmn.restapi.data.model.StagedJob;
 import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.data.repository.ObservableItemRepository;
 import au.org.aodn.nrmn.restapi.enums.Directions;
+import au.org.aodn.nrmn.restapi.service.formatting.SpeciesFormattingService;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
 import au.org.aodn.nrmn.restapi.test.PostgresqlContainerExtension;
 import au.org.aodn.nrmn.restapi.test.annotations.WithTestData;
 import au.org.aodn.nrmn.restapi.util.TimeUtils;
@@ -36,7 +36,7 @@ import au.org.aodn.nrmn.restapi.util.TimeUtils;
 class StagedRowFormattedMappingIT {
 
     @Autowired
-    ValidationProcess validationProcess;
+    SpeciesFormattingService speciesFormatting;
 
     @Autowired
     ObservableItemRepository observableItemRepository;
@@ -81,7 +81,7 @@ class StagedRowFormattedMappingIT {
 
         Collection<ObservableItem> species = observableItemRepository
                 .getAllSpeciesNamesMatching(Arrays.asList(row.getSpecies()));
-        Collection<StagedRowFormatted> validatedRows = validationProcess.formatRowsWithSpecies(Arrays.asList(row),
+        Collection<StagedRowFormatted> validatedRows = speciesFormatting.formatRowsWithSpecies(Arrays.asList(row),
                 species);
 
         assertEquals(1, validatedRows.size());
@@ -141,7 +141,7 @@ class StagedRowFormattedMappingIT {
         Collection<ObservableItem> species = observableItemRepository
                 .getAllSpeciesNamesMatching(Arrays.asList(row.getSpecies()));
 
-        Collection<StagedRowFormatted> validatedRows = validationProcess
+        Collection<StagedRowFormatted> validatedRows = speciesFormatting
                 .formatRowsWithSpecies(Arrays.asList(row), species);
 
         assertEquals(1, validatedRows.size());
@@ -191,7 +191,7 @@ class StagedRowFormattedMappingIT {
     
             Collection<ObservableItem> species = observableItemRepository
                     .getAllSpeciesNamesMatching(Arrays.asList(row.getSpecies()));
-            Collection<StagedRowFormatted> validatedRows = validationProcess.formatRowsWithSpecies(Arrays.asList(row),
+            Collection<StagedRowFormatted> validatedRows = speciesFormatting.formatRowsWithSpecies(Arrays.asList(row),
                     species);
 
             StagedRowFormatted formattedRow = (StagedRowFormatted) validatedRows.toArray()[0];

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ValidationProcessIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ValidationProcessIT.java
@@ -122,7 +122,7 @@ public class ValidationProcessIT extends FormattedTestProvider {
                 .depth(depth)
                 .build();
 
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false,
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true,
                 Collections.singletonList("erz1"), Collections.emptyList(), Collections.singletonList(row));
 
         Assertions.assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Site Code does not exist")));
@@ -137,7 +137,7 @@ public class ValidationProcessIT extends FormattedTestProvider {
                 .date(date)
                 .depth(depth)
                 .build();
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false,
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true,
                 Collections.singletonList("erz1"), Collections.emptyList(), Collections.singletonList(row));
 
         Assertions.assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Site Code does not exist")));
@@ -152,7 +152,7 @@ public class ValidationProcessIT extends FormattedTestProvider {
                 .date(date)
                 .depth(depth)
                 .build();
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false,
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true,
                 Collections.singletonList("erz1"), Collections.emptyList(), Collections.singletonList(row));
 
         Assertions.assertTrue(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Site Code does not exist")));

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ValidationProcessIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ValidationProcessIT.java
@@ -26,6 +26,7 @@ import au.org.aodn.nrmn.restapi.enums.SourceJobType;
 import au.org.aodn.nrmn.restapi.enums.StatusJobType;
 import au.org.aodn.nrmn.restapi.model.db.ProgramTestData;
 import au.org.aodn.nrmn.restapi.model.db.SecUserTestData;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
 import au.org.aodn.nrmn.restapi.test.PostgresqlContainerExtension;
 import au.org.aodn.nrmn.restapi.test.annotations.WithNoData;
@@ -36,6 +37,9 @@ import au.org.aodn.nrmn.restapi.validation.process.FormattedTestProvider;
 @ExtendWith(PostgresqlContainerExtension.class)
 @WithNoData
 public class ValidationProcessIT extends FormattedTestProvider {
+
+    @Autowired
+    private DataValidation dataValidation;
 
     @Autowired
     private ValidationProcess validationProcess;
@@ -118,7 +122,7 @@ public class ValidationProcessIT extends FormattedTestProvider {
                 .depth(depth)
                 .build();
 
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false,
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false,
                 Collections.singletonList("erz1"), Collections.emptyList(), Collections.singletonList(row));
 
         Assertions.assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Site Code does not exist")));
@@ -133,7 +137,7 @@ public class ValidationProcessIT extends FormattedTestProvider {
                 .date(date)
                 .depth(depth)
                 .build();
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false,
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false,
                 Collections.singletonList("erz1"), Collections.emptyList(), Collections.singletonList(row));
 
         Assertions.assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Site Code does not exist")));
@@ -148,7 +152,7 @@ public class ValidationProcessIT extends FormattedTestProvider {
                 .date(date)
                 .depth(depth)
                 .build();
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false,
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false,
                 Collections.singletonList("erz1"), Collections.emptyList(), Collections.singletonList(row));
 
         Assertions.assertTrue(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Site Code does not exist")));

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCDepthValidationTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCDepthValidationTest.java
@@ -20,7 +20,7 @@ import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.SurveyValidation;
 
 @ExtendWith(MockitoExtension.class)
 class ATRCDepthValidationTest {
@@ -38,7 +38,7 @@ class ATRCDepthValidationTest {
   DataValidation dataValidation;
 
   @InjectMocks
-  ValidationProcess validationProcess;
+  SurveyValidation surveyValidation;
 
   @Test
   void nullDepthShouldFail() {
@@ -60,7 +60,7 @@ class ATRCDepthValidationTest {
     job.setId(1L);
     StagedRowFormatted stage = new StagedRowFormatted();
     stage.setSurveyNum(9);
-    SurveyValidationError error = validationProcess.validateSurveyTransectNumber(Arrays.asList(stage));
+    SurveyValidationError error = surveyValidation.validateSurveyTransectNumber(Arrays.asList(stage));
     assertTrue(error.getMessage().equals("Survey group transect invalid"));
   }
 
@@ -72,7 +72,7 @@ class ATRCDepthValidationTest {
     row.setDepth(7);
     row.setSurveyNum(3);
     row.setMethod(1);
-    SurveyValidationError error = validationProcess.validateSurveyTransectNumber(Arrays.asList(row));
+    SurveyValidationError error = surveyValidation.validateSurveyTransectNumber(Arrays.asList(row));
     assertTrue(error == null);
   }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCDepthValidationTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCDepthValidationTest.java
@@ -49,7 +49,7 @@ class ATRCDepthValidationTest {
     row.setDepth("");
     row.setBlock("");
     row.setStagedJob(job);
-    Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
+    Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(),
         Arrays.asList(), Arrays.asList(row));
     assertTrue(errors.stream().anyMatch(e -> e.getMessage().equals("Depth is invalid, expected: depth[.surveyNum]")));
   }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCDepthValidationTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCDepthValidationTest.java
@@ -1,4 +1,4 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -18,6 +18,7 @@ import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
 import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
 
@@ -34,6 +35,9 @@ class ATRCDepthValidationTest {
   SiteRepository siteRepository;
 
   @InjectMocks
+  DataValidation dataValidation;
+
+  @InjectMocks
   ValidationProcess validationProcess;
 
   @Test
@@ -45,7 +49,7 @@ class ATRCDepthValidationTest {
     row.setDepth("");
     row.setBlock("");
     row.setStagedJob(job);
-    Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
+    Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(),
         Arrays.asList(), Arrays.asList(row));
     assertTrue(errors.stream().anyMatch(e -> e.getMessage().equals("Depth is invalid, expected: depth[.surveyNum]")));
   }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCMethod7BlockCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCMethod7BlockCheckTest.java
@@ -1,4 +1,4 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -19,7 +19,7 @@ import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 
 @ExtendWith(MockitoExtension.class)
 class ATRCMethod7BlockCheckTest {
@@ -34,7 +34,7 @@ class ATRCMethod7BlockCheckTest {
     SiteRepository siteRepository;
 
     @InjectMocks
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;  
 
     @Test
     void method7OnBlock2ShouldSucceed() {
@@ -44,7 +44,7 @@ class ATRCMethod7BlockCheckTest {
         row.setMethod("7");
         row.setBlock("2");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("ATRC Method 7")));
     }
 
@@ -56,7 +56,7 @@ class ATRCMethod7BlockCheckTest {
         row.setMethod("7");
         row.setBlock("3");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("ATRC Method 7")));
     }
 
@@ -68,7 +68,7 @@ class ATRCMethod7BlockCheckTest {
         row.setMethod("2");
         row.setBlock("2");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("ATRC Method 7")));
     }
 

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCMethod7BlockCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ATRCMethod7BlockCheckTest.java
@@ -44,7 +44,7 @@ class ATRCMethod7BlockCheckTest {
         row.setMethod("7");
         row.setBlock("2");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("ATRC Method 7")));
     }
 
@@ -56,7 +56,7 @@ class ATRCMethod7BlockCheckTest {
         row.setMethod("7");
         row.setBlock("3");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("ATRC Method 7")));
     }
 
@@ -68,7 +68,7 @@ class ATRCMethod7BlockCheckTest {
         row.setMethod("2");
         row.setBlock("2");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("ATRC Method 7")));
     }
 

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/Block0DataCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/Block0DataCheckTest.java
@@ -1,7 +1,7 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,10 +19,11 @@ import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 
 @ExtendWith(MockitoExtension.class)
-class DirectionDataCheckTest {
+class Block0DataCheckTest {
+
     @Mock
     ObservationRepository observationRepository;
 
@@ -33,27 +34,29 @@ class DirectionDataCheckTest {
     SiteRepository siteRepository;
 
     @InjectMocks
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @Test
-    void invalidDirectionShouldFail() {
+    void block0MethodOutOfRangeShouldFail() {
         StagedJob job = new StagedJob();
         job.setId(1L);
         StagedRow row = new StagedRow();
+        row.setBlock("0");
+        row.setMethod("2");
         row.setStagedJob(job);
-        row.setDirection("ED");
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
-        assertTrue(errors.stream().anyMatch(e -> e.getMessage().equals("Direction is not valid")));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        assertTrue(errors.stream().anyMatch(e -> e.getMessage().equals("Block 0 is invalid for method")));
     }
 
     @Test
-    void validDirectionShouldSucceed() {
+    void block0MethodInRangeShouldSucceed() {
         StagedJob job = new StagedJob();
         job.setId(1L);
         StagedRow row = new StagedRow();
+        row.setBlock("0");
+        row.setMethod("5");
         row.setStagedJob(job);
-        row.setDirection("NE");
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
-        assertFalse(errors.stream().anyMatch(e -> e.getMessage().equals("Direction is not valid")));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        assertFalse(errors.stream().anyMatch(e -> e.getMessage().equals("Block 0 is invalid for method")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/Block0DataCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/Block0DataCheckTest.java
@@ -44,7 +44,7 @@ class Block0DataCheckTest {
         row.setBlock("0");
         row.setMethod("2");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().equals("Block 0 is invalid for method")));
     }
 
@@ -56,7 +56,7 @@ class Block0DataCheckTest {
         row.setBlock("0");
         row.setMethod("5");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().equals("Block 0 is invalid for method")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/DirectionDataCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/DirectionDataCheckTest.java
@@ -1,7 +1,7 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.Assert.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -19,11 +19,10 @@ import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 
 @ExtendWith(MockitoExtension.class)
-class Block0DataCheckTest {
-
+class DirectionDataCheckTest {
     @Mock
     ObservationRepository observationRepository;
 
@@ -34,29 +33,27 @@ class Block0DataCheckTest {
     SiteRepository siteRepository;
 
     @InjectMocks
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @Test
-    void block0MethodOutOfRangeShouldFail() {
+    void invalidDirectionShouldFail() {
         StagedJob job = new StagedJob();
         job.setId(1L);
         StagedRow row = new StagedRow();
-        row.setBlock("0");
-        row.setMethod("2");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
-        assertTrue(errors.stream().anyMatch(e -> e.getMessage().equals("Block 0 is invalid for method")));
+        row.setDirection("ED");
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        assertTrue(errors.stream().anyMatch(e -> e.getMessage().equals("Direction is not valid")));
     }
 
     @Test
-    void block0MethodInRangeShouldSucceed() {
+    void validDirectionShouldSucceed() {
         StagedJob job = new StagedJob();
         job.setId(1L);
         StagedRow row = new StagedRow();
-        row.setBlock("0");
-        row.setMethod("5");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
-        assertFalse(errors.stream().anyMatch(e -> e.getMessage().equals("Block 0 is invalid for method")));
+        row.setDirection("NE");
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        assertFalse(errors.stream().anyMatch(e -> e.getMessage().equals("Direction is not valid")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/DirectionDataCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/DirectionDataCheckTest.java
@@ -42,7 +42,7 @@ class DirectionDataCheckTest {
         StagedRow row = new StagedRow();
         row.setStagedJob(job);
         row.setDirection("ED");
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().equals("Direction is not valid")));
     }
 
@@ -53,7 +53,7 @@ class DirectionDataCheckTest {
         StagedRow row = new StagedRow();
         row.setStagedJob(job);
         row.setDirection("NE");
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().equals("Direction is not valid")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/DuplicateRowCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/DuplicateRowCheckTest.java
@@ -44,7 +44,7 @@ class DuplicateRowCheckTest {
             put(2, "4");
         }}).build();
 
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
         assertTrue(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 
@@ -65,7 +65,7 @@ class DuplicateRowCheckTest {
             put(5, "47");
         }}).build();
 
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
         assertTrue(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 
@@ -84,7 +84,7 @@ class DuplicateRowCheckTest {
             put(2, "4");
         }}).build();
 
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
         assertFalse(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/DuplicateRowCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/DuplicateRowCheckTest.java
@@ -1,4 +1,4 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,14 +18,13 @@ import au.org.aodn.nrmn.restapi.data.repository.DiverRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.enums.ValidationLevel;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 
 @ExtendWith(MockitoExtension.class)
 class DuplicateRowCheckTest {
 
     @InjectMocks
-    ValidationProcess validationProcess;
-
+    DataValidation dataValidation;
     
     @Mock
     DiverRepository diverRepository;
@@ -45,7 +44,7 @@ class DuplicateRowCheckTest {
             put(2, "4");
         }}).build();
 
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
         assertTrue(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 
@@ -66,7 +65,7 @@ class DuplicateRowCheckTest {
             put(5, "47");
         }}).build();
 
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
         assertTrue(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 
@@ -85,7 +84,7 @@ class DuplicateRowCheckTest {
             put(2, "4");
         }}).build();
 
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(r1, r2, r3));
         assertFalse(res.stream().anyMatch(e -> e.getLevelId() == ValidationLevel.DUPLICATE));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/MeasureJsonValidationTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/MeasureJsonValidationTest.java
@@ -45,7 +45,7 @@ class MeasureJsonValidationTest {
                 }
         );
         row.setStagedJob(job);
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Measurement is not valid")));
     }
 
@@ -64,7 +64,7 @@ class MeasureJsonValidationTest {
                 }
         );
         row.setStagedJob(job);
-        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertTrue(res.stream().filter(e -> e.getMessage().equalsIgnoreCase("Measurement is not valid")).count() == 2);
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/MeasureJsonValidationTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/MeasureJsonValidationTest.java
@@ -1,4 +1,4 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -18,14 +18,13 @@ import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.data.repository.DiverRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 
 @ExtendWith(MockitoExtension.class)
 class MeasureJsonValidationTest {
 
     @InjectMocks
-    ValidationProcess validationProcess;
-
+    DataValidation dataValidation;
     
     @Mock
     DiverRepository diverRepository;
@@ -46,7 +45,7 @@ class MeasureJsonValidationTest {
                 }
         );
         row.setStagedJob(job);
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertFalse(res.stream().anyMatch(e -> e.getMessage().equalsIgnoreCase("Measurement is not valid")));
     }
 
@@ -65,7 +64,7 @@ class MeasureJsonValidationTest {
                 }
         );
         row.setStagedJob(job);
-        Collection<SurveyValidationError> res = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> res = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList("ERZ1"), Arrays.asList(), Arrays.asList(row));
         assertTrue(res.stream().filter(e -> e.getMessage().equalsIgnoreCase("Measurement is not valid")).count() == 2);
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/RLSDepthValidationTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/RLSDepthValidationTest.java
@@ -1,4 +1,4 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.Assert.assertTrue;
 
@@ -18,7 +18,7 @@ import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 
 @ExtendWith(MockitoExtension.class)
 class RLSDepthValidationTest {
@@ -32,7 +32,7 @@ class RLSDepthValidationTest {
     SiteRepository siteRepository;
 
     @InjectMocks
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @Test
     void depthWithMulipleDecimalsShouldFail() {
@@ -41,7 +41,7 @@ class RLSDepthValidationTest {
         StagedRow row = new StagedRow();
         row.setDepth("3.14");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Depth is invalid, expected: depth[.surveyNum]")));
     }
 
@@ -52,7 +52,7 @@ class RLSDepthValidationTest {
         StagedRow row = new StagedRow();
         row.setDepth(null);
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Depth is invalid, expected: depth[.surveyNum]")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/RLSDepthValidationTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/RLSDepthValidationTest.java
@@ -41,7 +41,7 @@ class RLSDepthValidationTest {
         StagedRow row = new StagedRow();
         row.setDepth("3.14");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Depth is invalid, expected: depth[.surveyNum]")));
     }
 
@@ -52,7 +52,7 @@ class RLSDepthValidationTest {
         StagedRow row = new StagedRow();
         row.setDepth(null);
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Depth is invalid, expected: depth[.surveyNum]")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/SpeciesSupersededTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/SpeciesSupersededTest.java
@@ -1,4 +1,4 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,13 +20,13 @@ import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.data.repository.DiverRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 
 @ExtendWith(MockitoExtension.class)
 class SpeciesSupersededTest {
 
     @InjectMocks
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @Mock
     DiverRepository diverRepository;
@@ -38,7 +38,7 @@ class SpeciesSupersededTest {
         StagedRow row = new StagedRow();
         row.setSpecies("THE SPECIES");
         List<ObservableItem> species = Arrays.asList(ObservableItem.builder().observableItemName("THE SPECIES").supersededBy("NEXT SPECIES").methods(methods).build());
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), species, Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), species, Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Superseded by")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/SpeciesSupersededTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/SpeciesSupersededTest.java
@@ -38,7 +38,7 @@ class SpeciesSupersededTest {
         StagedRow row = new StagedRow();
         row.setSpecies("THE SPECIES");
         List<ObservableItem> species = Arrays.asList(ObservableItem.builder().observableItemName("THE SPECIES").supersededBy("NEXT SPECIES").methods(methods).build());
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), species, Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), species, Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Superseded by")));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ValidationProcessTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ValidationProcessTest.java
@@ -45,7 +45,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime("ti:me");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -56,7 +56,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime("10:15");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -67,7 +67,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime("40:15");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -92,7 +92,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime(value);
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -103,7 +103,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime("");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -114,7 +114,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setVis("-99");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Vis is not positive")));
     }
 
@@ -125,7 +125,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setVis("");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Vis")));
     }
 
@@ -136,7 +136,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTotal("Not a number");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Total is not an integer")));
     }
 
@@ -147,7 +147,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTotal("10");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Total is not an integer")));
     }
 
@@ -158,7 +158,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setLongitude("-67.192519");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Longitude")));
     }
 
@@ -170,7 +170,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setDate("not /at /date");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Date format is not valid")));
     }
 
@@ -181,7 +181,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setDate("11/09/2018");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Date format is not valid")));
     }
 
@@ -192,7 +192,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setDate("11/9/18");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Date format is not valid")));
     }
     
@@ -204,7 +204,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("no");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
     }
 
@@ -215,7 +215,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("yes");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
     }
 
@@ -227,7 +227,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("True");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
     }
 
@@ -239,7 +239,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("false");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
     }
 
@@ -251,7 +251,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Use Invert Sizing is blank")));
     }
 
@@ -262,7 +262,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), true, Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Use Invert Sizing is blank")));
     }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ValidationProcessTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/data/ValidationProcessTest.java
@@ -1,4 +1,4 @@
-package au.org.aodn.nrmn.restapi.validation.process;
+package au.org.aodn.nrmn.restapi.validation.data;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -21,7 +21,7 @@ import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 
 @ExtendWith(MockitoExtension.class)
 class ValidationProcessTest {
@@ -36,7 +36,7 @@ class ValidationProcessTest {
     SiteRepository siteRepository;
 
     @InjectMocks
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @Test
     void incorrectTimeFormatShouldFail() {
@@ -45,7 +45,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime("ti:me");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -56,7 +56,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime("10:15");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -67,7 +67,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime("40:15");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -92,7 +92,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime(value);
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -103,7 +103,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTime("");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Time format is not valid")));
     }
 
@@ -114,7 +114,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setVis("-99");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Vis is not positive")));
     }
 
@@ -125,7 +125,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setVis("");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Vis")));
     }
 
@@ -136,7 +136,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTotal("Not a number");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Total is not an integer")));
     }
 
@@ -147,7 +147,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setTotal("10");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Total is not an integer")));
     }
 
@@ -158,7 +158,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setLongitude("-67.192519");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Longitude")));
     }
 
@@ -170,7 +170,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setDate("not /at /date");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Date format is not valid")));
     }
 
@@ -181,7 +181,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setDate("11/09/2018");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Date format is not valid")));
     }
 
@@ -192,7 +192,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setDate("11/9/18");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Date format is not valid")));
     }
     
@@ -204,7 +204,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("no");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
     }
 
@@ -215,7 +215,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("yes");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
     }
 
@@ -227,7 +227,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("True");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
     }
 
@@ -239,7 +239,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("false");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
     }
 
@@ -251,7 +251,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertTrue(errors.stream().anyMatch(e -> e.getMessage().contains("Use Invert Sizing is blank")));
     }
 
@@ -262,7 +262,7 @@ class ValidationProcessTest {
         StagedRow row = new StagedRow();
         row.setIsInvertSizing("");
         row.setStagedJob(job);
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, job.getIsExtendedSize(), Arrays.asList(), Arrays.asList(), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("must be 'Yes' or 'No'")));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("Use Invert Sizing is blank")));
     }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/measurement/NoSpeciesFoundMeasurementsTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/measurement/NoSpeciesFoundMeasurementsTest.java
@@ -16,7 +16,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
 
-import au.org.aodn.nrmn.restapi.dto.stage.ValidationCell;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.data.model.ObsItemType;
 import au.org.aodn.nrmn.restapi.data.model.ObservableItem;
@@ -24,9 +23,9 @@ import au.org.aodn.nrmn.restapi.data.model.StagedJob;
 import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.data.repository.DiverRepository;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
+import au.org.aodn.nrmn.restapi.service.validation.DataValidation;
 import au.org.aodn.nrmn.restapi.service.validation.MeasurementValidation;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
-import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
 
 @ExtendWith(MockitoExtension.class)
 class NoSpeciesFoundMeasurementsTest {
@@ -35,7 +34,7 @@ class NoSpeciesFoundMeasurementsTest {
     DiverRepository diverRepository;
     
     @InjectMocks
-    ValidationProcess validationProcess;
+    DataValidation dataValidation;
 
     @InjectMocks
     MeasurementValidation measurementValidation;
@@ -49,7 +48,7 @@ class NoSpeciesFoundMeasurementsTest {
         row.setMeasureJson(ImmutableMap.<Integer, String>builder().put(1, "2").build());
         row.setSpecies("Pictilabrus laticlavius");
         ObservableItem item = ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(1).build()).observableItemName("Pictilabrus laticlavius").letterCode("pla").build();
-        Collection<SurveyValidationError> errors = validationProcess.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(item), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(item), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("species")));
     }
 

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/measurement/NoSpeciesFoundMeasurementsTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/measurement/NoSpeciesFoundMeasurementsTest.java
@@ -48,7 +48,7 @@ class NoSpeciesFoundMeasurementsTest {
         row.setMeasureJson(ImmutableMap.<Integer, String>builder().put(1, "2").build());
         row.setSpecies("Pictilabrus laticlavius");
         ObservableItem item = ObservableItem.builder().obsItemType(ObsItemType.builder().obsItemTypeId(1).build()).observableItemName("Pictilabrus laticlavius").letterCode("pla").build();
-        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, Arrays.asList(), Arrays.asList(item), Arrays.asList(row));
+        Collection<SurveyValidationError> errors = dataValidation.checkFormatting(ProgramValidation.ATRC, false, true, Arrays.asList(), Arrays.asList(item), Arrays.asList(row));
         assertFalse(errors.stream().anyMatch(e -> e.getMessage().contains("species")));
     }
 

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/BeforeDateCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/BeforeDateCheckTest.java
@@ -18,6 +18,7 @@ import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.service.validation.MeasurementValidation;
+import au.org.aodn.nrmn.restapi.service.validation.SiteValidation;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
 import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
 
@@ -30,6 +31,9 @@ class BeforeDateCheckTest {
     @Mock
     MeasurementValidation measurementValidation;
     
+    @Mock
+    SiteValidation siteValidation;
+
     @Test
     void beforeDateShouldSucceed() throws Exception {
 

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/BeforeDateCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/BeforeDateCheckTest.java
@@ -1,11 +1,9 @@
 package au.org.aodn.nrmn.restapi.validation.process;
 
-import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -15,11 +13,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import au.org.aodn.nrmn.restapi.data.model.StagedJob;
 import au.org.aodn.nrmn.restapi.data.model.StagedRow;
-import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.service.validation.MeasurementValidation;
 import au.org.aodn.nrmn.restapi.service.validation.SiteValidation;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
+import au.org.aodn.nrmn.restapi.service.validation.SurveyValidation;
 import au.org.aodn.nrmn.restapi.service.validation.ValidationProcess;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,6 +32,9 @@ class BeforeDateCheckTest {
     @Mock
     SiteValidation siteValidation;
 
+    @InjectMocks
+    SurveyValidation surveyValidation;
+
     @Test
     void beforeDateShouldSucceed() throws Exception {
 
@@ -47,8 +48,8 @@ class BeforeDateCheckTest {
         StagedRowFormatted rowFormatted = new StagedRowFormatted();
         rowFormatted.setDate(LocalDate.parse("1990-01-01"));
         rowFormatted.setRef(row);
-        Collection<SurveyValidationError> errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(rowFormatted));
-        assertTrue(errors.stream().anyMatch(e -> e.getMessage().startsWith("Date must be after")));
+        var error = surveyValidation.validateDateRange(ProgramValidation.ATRC, rowFormatted);
+        assertTrue(error.getMessage().contains("Date must be after"));
     }
 
     @Test
@@ -63,8 +64,8 @@ class BeforeDateCheckTest {
         StagedRowFormatted rowFormatted = new StagedRowFormatted();
         rowFormatted.setDate(LocalDate.parse("2100-01-01"));
         rowFormatted.setRef(row);
-        Collection<SurveyValidationError> errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(rowFormatted));
-        assertTrue(errors.stream().anyMatch(e -> e.getMessage().startsWith("Date is in the future")));
+        var error = surveyValidation.validateDateRange(ProgramValidation.ATRC, rowFormatted);
+        assertTrue(error.getMessage().contains("Date is in the future"));
     }
 
     @Test
@@ -79,9 +80,7 @@ class BeforeDateCheckTest {
         StagedRowFormatted rowFormatted = new StagedRowFormatted();
         rowFormatted.setDate(LocalDate.parse("1991-01-01"));
         rowFormatted.setRef(row);
-
-        Collection<SurveyValidationError> errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(rowFormatted));
-        assertFalse(errors.stream().anyMatch(e -> e.getMessage().startsWith("Date is in the future")));
-        assertFalse(errors.stream().anyMatch(e -> e.getMessage().startsWith("Date must be after")));
+        var error = surveyValidation.validateDateRange(ProgramValidation.ATRC, rowFormatted);
+        assertNull(error);
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/Method3QuadratsMissingTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/Method3QuadratsMissingTest.java
@@ -6,11 +6,16 @@ import java.util.Arrays;
 import java.util.HashMap;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
+import au.org.aodn.nrmn.restapi.service.validation.SurveyValidation;
 
 class Method3QuadratsMissingTest extends FormattedTestProvider {
+
+    @InjectMocks
+    SurveyValidation surveyValidation;
 
     @Test
     void transectWithAllQuadratsFilledShouldSuccess() {
@@ -38,7 +43,7 @@ class Method3QuadratsMissingTest extends FormattedTestProvider {
             }
         });
 
-        SurveyValidationError error = validationProcess.validateMethod3Quadrats("0", Arrays.asList(r1, r2, r3));
+        SurveyValidationError error = surveyValidation.validateMethod3Quadrats("0", Arrays.asList(r1, r2, r3));
         assertTrue(error == null);
     }
 
@@ -61,7 +66,7 @@ class Method3QuadratsMissingTest extends FormattedTestProvider {
             }
         });
         
-        SurveyValidationError error = validationProcess.validateMethod3Quadrats("0", Arrays.asList(r1, r2));
+        SurveyValidationError error = surveyValidation.validateMethod3Quadrats("0", Arrays.asList(r1, r2));
         assertTrue(error != null);
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/Method3QuadratsSumTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/Method3QuadratsSumTest.java
@@ -9,12 +9,18 @@ import java.util.Collection;
 import java.util.HashMap;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
 
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.dto.stage.ValidationCell;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
+import au.org.aodn.nrmn.restapi.service.validation.SurveyValidation;
 
 class Method3QuadratsSumTest extends FormattedTestProvider {
+
+    @InjectMocks
+    SurveyValidation surveyValidation;
+
     @Test
     void quadratsSumUnder50ShouldFail() {
         StagedRowFormatted r1 = getDefaultFormatted().build();
@@ -92,7 +98,7 @@ class Method3QuadratsSumTest extends FormattedTestProvider {
             }
         });
 
-        SurveyValidationError error = validationProcess.validateMethod3QuadratsGT50("", Arrays.asList(r1, r2, r3, r4, a1, a2, a3, a4));
+        SurveyValidationError error = surveyValidation.validateMethod3QuadratsGT50("", Arrays.asList(r1, r2, r3, r4, a1, a2, a3, a4));
         assertTrue(error != null && error.getMessage().startsWith("Quadrats do not sum to at least 50 in transect"));
     }
 
@@ -178,7 +184,7 @@ class Method3QuadratsSumTest extends FormattedTestProvider {
             }
         });
 
-        Collection<ValidationCell> errors = validationProcess.validateMethod3QuadratsLT50(Arrays.asList(r1, r2, r3, r4, a1, a2, a3, a4));
+        Collection<ValidationCell> errors = surveyValidation.validateMethod3QuadratsLT50(Arrays.asList(r1, r2, r3, r4, a1, a2, a3, a4));
         assertTrue(errors != null && errors.iterator().next().getMessage().startsWith("M3 quadrat more than 50"));
     }
 
@@ -264,7 +270,7 @@ class Method3QuadratsSumTest extends FormattedTestProvider {
             }
         });
 
-        SurveyValidationError error = validationProcess.validateMethod3QuadratsGT50("", Arrays.asList(r1, r2, r3, r4, a1, a2, a3, a4));
+        SurveyValidationError error = surveyValidation.validateMethod3QuadratsGT50("", Arrays.asList(r1, r2, r3, r4, a1, a2, a3, a4));
         assertFalse(error != null && error.getMessage().startsWith("Quadrats do not sum to at least 50 in transect"));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/SpeciesBelongToMethodCheckTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/SpeciesBelongToMethodCheckTest.java
@@ -5,6 +5,7 @@ import au.org.aodn.nrmn.restapi.data.model.ObservableItem;
 import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.service.validation.MeasurementValidation;
+import au.org.aodn.nrmn.restapi.service.validation.SiteValidation;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
 
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,9 @@ class SpeciesBelongToMethodCheckTest extends FormattedTestProvider {
     
     @Mock
     MeasurementValidation measurementValidation;
+
+    @Mock
+    SiteValidation siteValidation;
 
     @Test
     public void matchingMethodShouldSuccess() {

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ZeroInvertsTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ZeroInvertsTest.java
@@ -4,10 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
-
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ZeroInvertsTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ZeroInvertsTest.java
@@ -1,16 +1,19 @@
 package au.org.aodn.nrmn.restapi.validation.process;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
+
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
-import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.service.validation.MeasurementValidation;
 import au.org.aodn.nrmn.restapi.service.validation.SiteValidation;
+import au.org.aodn.nrmn.restapi.service.validation.SurveyValidation;
 
 class ZeroInvertsTest extends FormattedTestProvider {
 
@@ -19,14 +22,17 @@ class ZeroInvertsTest extends FormattedTestProvider {
     
     @Mock
     SiteValidation siteValidation;
+
+    @InjectMocks 
+    SurveyValidation surveyValidation;
     
     @Test
     void method3WithInvertsShouldSucceed() {
         var formatted = getDefaultFormatted().build();
         formatted.setMethod(3);
         formatted.setInverts(0);
-        var errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
-        assertFalse(errors.stream().anyMatch(p -> p.getMessage().contains("Method 3")));
+        var error = surveyValidation.validateInvertsZeroOnM3M4M5(formatted);
+        assertNull(error);
     }
 
     @Test
@@ -34,8 +40,9 @@ class ZeroInvertsTest extends FormattedTestProvider {
         var formatted = getDefaultFormatted().build();
         formatted.setMethod(3);
         formatted.setInverts(5);
-        var errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
-        assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Method 3")));
+        var error = surveyValidation.validateInvertsZeroOnM3M4M5(formatted);
+        assertNotNull(error);
+        assertTrue(error.getMessage().contains("Method 3"));
     }
 
     @Test
@@ -43,8 +50,9 @@ class ZeroInvertsTest extends FormattedTestProvider {
         var formatted = getDefaultFormatted().build();
         formatted.setMethod(4);
         formatted.setInverts(5);
-        var errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
-        assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Method 4")));
+        var error = surveyValidation.validateInvertsZeroOnM3M4M5(formatted);
+        assertNotNull(error);
+        assertTrue(error.getMessage().contains("Method 4"));
     }
 
     @Test
@@ -52,7 +60,8 @@ class ZeroInvertsTest extends FormattedTestProvider {
         var formatted = getDefaultFormatted().build();
         formatted.setMethod(5);
         formatted.setInverts(5);
-        var errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
-        assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Method 5")));
+        var error = surveyValidation.validateInvertsZeroOnM3M4M5(formatted);
+        assertNotNull(error);
+        assertTrue(error.getMessage().contains("Method 5"));
     }
 }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ZeroInvertsTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/validation/process/ZeroInvertsTest.java
@@ -4,54 +4,55 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
-import java.util.Collection;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
-import au.org.aodn.nrmn.restapi.dto.stage.SurveyValidationError;
 import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import au.org.aodn.nrmn.restapi.service.validation.MeasurementValidation;
-import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
+import au.org.aodn.nrmn.restapi.service.validation.SiteValidation;
 
 class ZeroInvertsTest extends FormattedTestProvider {
 
     @Mock
     MeasurementValidation measurementValidation;
     
+    @Mock
+    SiteValidation siteValidation;
+    
     @Test
     void method3WithInvertsShouldSucceed() {
-        StagedRowFormatted formatted = getDefaultFormatted().build();
+        var formatted = getDefaultFormatted().build();
         formatted.setMethod(3);
         formatted.setInverts(0);
-        Collection<SurveyValidationError> errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
+        var errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
         assertFalse(errors.stream().anyMatch(p -> p.getMessage().contains("Method 3")));
     }
 
     @Test
     void method3WithInvertsShouldFail() {
-        StagedRowFormatted formatted = getDefaultFormatted().build();
+        var formatted = getDefaultFormatted().build();
         formatted.setMethod(3);
         formatted.setInverts(5);
-        Collection<SurveyValidationError> errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
+        var errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
         assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Method 3")));
     }
 
     @Test
     void method4WithInvertsShouldFail() {
-        StagedRowFormatted formatted = getDefaultFormatted().build();
+        var formatted = getDefaultFormatted().build();
         formatted.setMethod(4);
         formatted.setInverts(5);
-        Collection<SurveyValidationError> errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
+        var errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
         assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Method 4")));
     }
 
     @Test
     void method5WithInvertsShouldFail() {
-        StagedRowFormatted formatted = getDefaultFormatted().build();
+        var formatted = getDefaultFormatted().build();
         formatted.setMethod(5);
         formatted.setInverts(5);
-        Collection<SurveyValidationError> errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
+        var errors = validationProcess.checkData(ProgramValidation.ATRC, false, Arrays.asList(formatted));
         assertTrue(errors.stream().anyMatch(p -> p.getMessage().contains("Method 5")));
     }
 }

--- a/web/src/components/data-entities/site/__test__/SiteList.test.tsx
+++ b/web/src/components/data-entities/site/__test__/SiteList.test.tsx
@@ -8,6 +8,8 @@ import SiteList from '../SiteList';
 import {Router} from 'react-router-dom';
 import {waitForDataToHaveLoaded} from '../../../../common/AgGridTestHelper';
 
+jest.setTimeout(10000);
+
 describe('<SiteList/>', () => {
   const siteTestData = {
       "lastRow": 3,

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -105,7 +105,7 @@ const SurveyCorrect = () => {
       {field: 'surveyId', label: 'Survey'},
       {field: 'diverId', label: 'Diver ID', hide: true},
       {field: 'diver', label: 'Diver'},
-      {field: 'siteCode', label: 'Site Code', hide: true},
+      {field: 'siteCode', label: 'Site Code'},
       {field: 'depth', label: 'Depth'},
       {field: 'date', label: 'Survey Date'},
       {field: 'time', label: 'Survey Time'},

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -102,7 +102,7 @@ const SurveyCorrect = () => {
     return [
       {field: 'pos', label: '', editable: false, hide: true, sort: 'asc'},
       {field: 'id', label: '', editable: false, hide: true},
-      {field: 'surveyId', label: 'Survey', editable: false},
+      {field: 'surveyId', label: 'Survey'},
       {field: 'diverId', label: 'Diver ID', hide: true},
       {field: 'diver', label: 'Diver'},
       {field: 'siteCode', label: 'Site Code', hide: true},

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -118,7 +118,8 @@ const SurveyCorrect = () => {
       {field: 'code', label: 'Letter Code'},
       {field: 'method', label: 'Method'},
       {field: 'block', label: 'Block'},
-      {field: 'isInvertSizing', label: 'Use Invert Sizing'}
+      {field: 'isInvertSizing', label: 'Use Invert Sizing'},
+      {field: 'inverts', label: 'Inverts'}
     ];
   }, []);
 
@@ -197,9 +198,11 @@ const SurveyCorrect = () => {
       const {rows, programValidation} = res.data;
       const unpackedData = rows.map((data, idx) => {
         const measurements = data.observationIds === '' ? {} : JSON.parse(data.measureJson);
+        const inverts = measurements[0] || '0';
+        delete measurements[0];
         const observationIds = data.observationIds === '' ? [] : JSON.parse(data.observationIds);
         delete data.measureJson;
-        return {id: (idx + 1) * 100, pos: (idx + 1) * 100, ...data, observationIds, measurements};
+        return {id: (idx + 1) * 100, pos: (idx + 1) * 100, ...data, inverts, observationIds, measurements};
       });
       const isExtended = unpackedData.includes(r => Object.keys(r.measurements).includes(k => k > 28));
       const context = api.gridOptionsWrapper.gridOptions.context;
@@ -368,7 +371,6 @@ const SurveyCorrect = () => {
                 editable={header.editable ?? true}
               />
           )}
-          <AgGridColumn editable field={'measurements.0'} headerName="Unsized" />
           {allMeasurements.map((_, idx) => {
             const field = `measurements.${idx + 1}`;
             return <AgGridColumn editable field={field} headerComponent={SurveyMeasurementHeader} key={idx} width={35} />;

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -20,11 +20,11 @@ const toolTipValueGetter = ({context, data, colDef}) => {
   if (!context.cellValidations) return;
   const row = data.id;
   const field = colDef.field;
-  const error = context.cellValidations[row]?.[field];
+  const error = context.cellValidations[row]?.[field] || context.cellValidations[row];
   if (error?.levelId === 'DUPLICATE') {
     const rowPositions = error.rowIds.map((r) => context.rowData.find((d) => d.id === r)?.pos).filter((r) => r);
     const duplicates = rowPositions.map((r) => context.rowPos.indexOf(r) + 1);
-    return duplicates.length > 1 ? 'Rows are duplicated: ' + duplicates.join(', ') : 'Duplicate rows have been removed';
+    return 'Rows are duplicated: ' + duplicates.join(', ');
   }
   return error?.message;
 };
@@ -84,9 +84,13 @@ const SurveyCorrect = () => {
     const cellFormat = [];
     for (const res of validationResult) {
       for (const row of res.rowIds) {
-        for (const col of res.columnNames) {
-          if (!cellFormat[row]) cellFormat[row] = {};
-          cellFormat[row][col] = {levelId: res.levelId, message: res.message};
+        if (!cellFormat[row]) cellFormat[row] = {};
+        if(res.columnNames) {
+          for (const col of res.columnNames) {
+            cellFormat[row][col] = {levelId: res.levelId, message: res.message};
+          }
+        } else {
+          cellFormat[row]['id'] = {levelId: res.levelId, message: res.message, rowIds: res.rowIds};
         }
       }
     }

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -115,7 +115,6 @@ const SurveyCorrect = () => {
       {field: 'longitude', label: 'Longitude'},
       {field: 'observableItemId', hide: true},
       {field: 'species', label: 'Species Name'},
-      {field: 'code', label: 'Letter Code'},
       {field: 'method', label: 'Method'},
       {field: 'block', label: 'Block'},
       {field: 'isInvertSizing', label: 'Use Invert Sizing'},

--- a/web/src/components/data-entities/survey/panel/SummaryPanel.js
+++ b/web/src/components/data-entities/survey/panel/SummaryPanel.js
@@ -44,7 +44,7 @@ const SummaryPanel = ({api, context}) => {
       }
       else
       {
-        const rowNumbers = validation.rowIds.map(r => (context.rowPos.indexOf(r) + 2));
+        const rowNumbers = validation.rowIds.map(r => (context.rowPos.indexOf(r) + 1));
         validation.id = validation.message + rowNumbers.join('.');
         validation.description = [{columnName: 'id', rowIds: validation.rowIds, rowNumbers, value:''}];
       }

--- a/web/src/components/data-entities/survey/panel/SummaryPanel.js
+++ b/web/src/components/data-entities/survey/panel/SummaryPanel.js
@@ -32,7 +32,7 @@ const SummaryPanel = ({api, context}) => {
   useEffect(() => {
     var formatted = [];
     for (const validation of context.validations) {
-      if (validation.rowIds.length == 1 || validation.columnNames.length == 1) {
+      if (validation.rowIds?.length == 1 || validation.columnNames?.length == 1) {
         const rowId = validation.rowIds[0];
         const rowData = api.getRowNode(rowId).data;
         const columnPath = validation.columnNames[0];
@@ -42,6 +42,12 @@ const SummaryPanel = ({api, context}) => {
         const rowNumbers = validation.rowIds.map(r => (context.rowPos.indexOf(r) + 1));
         validation.description = [{...col, rowIds: validation.rowIds, rowNumbers, value}];
       }
+      else if(validation.levelId === 'DUPLICATE') {
+        const rowNumbers = validation.rowIds.map(r => (context.rowPos.indexOf(r) + 2));
+        validation.id = 'duplicate' + rowNumbers.join('.');
+        validation.description = [{columnName: 'id', rowIds: validation.rowIds, rowNumbers, value:''}];
+      }
+
       formatted.push(validation);
     }
     setMessages(groupArrayByKey(formatted, 'levelId'));
@@ -88,7 +94,7 @@ const SummaryPanel = ({api, context}) => {
                                 Check Column{d.columnNames.length > 1 ? 's' : ''} {d.columnNames.join(', ')}
                               </b>
                             ) : (
-                              <b>Rows {d.rowNumbers.join(', ')}</b>
+                              <b>Rows {d.rowNumbers.sort().join(', ')}</b>
                             )}
                           </Typography>
                         }

--- a/web/src/components/data-entities/survey/panel/SummaryPanel.js
+++ b/web/src/components/data-entities/survey/panel/SummaryPanel.js
@@ -32,7 +32,7 @@ const SummaryPanel = ({api, context}) => {
   useEffect(() => {
     var formatted = [];
     for (const validation of context.validations) {
-      if (validation.rowIds?.length == 1 || validation.columnNames?.length == 1) {
+      if (validation.rowIds?.length == 1 && validation.columnNames) {
         const rowId = validation.rowIds[0];
         const rowData = api.getRowNode(rowId).data;
         const columnPath = validation.columnNames[0];
@@ -42,9 +42,10 @@ const SummaryPanel = ({api, context}) => {
         const rowNumbers = validation.rowIds.map(r => (context.rowPos.indexOf(r) + 1));
         validation.description = [{...col, rowIds: validation.rowIds, rowNumbers, value}];
       }
-      else if(validation.levelId === 'DUPLICATE') {
+      else
+      {
         const rowNumbers = validation.rowIds.map(r => (context.rowPos.indexOf(r) + 2));
-        validation.id = 'duplicate' + rowNumbers.join('.');
+        validation.id = validation.message + rowNumbers.join('.');
         validation.description = [{columnName: 'id', rowIds: validation.rowIds, rowNumbers, value:''}];
       }
 
@@ -68,11 +69,11 @@ const SummaryPanel = ({api, context}) => {
                   key={`${m.id}`}
                   label={
                     <Typography variant="body2">
-                      {m.message} {m.description.length > 1 ? '(' + m.description.length + ')' : ''}
+                      {m.message} {m.description?.length > 1 ? '(' + m.description.length + ')' : ''}
                     </Typography>
                   }
                 >
-                  {m.description.map((d) => {
+                  {m.description?.map((d) => {
                     const mmHeader = mm.find((m) => m.field === d.columnName.replace('measurements.', ''));
                     const label = mmHeader ? `${d.isInvertSize ? mmHeader.invertSize : mmHeader.fishSize}cm` : d.columnName;
                     return (

--- a/web/src/components/import/DataSheetEventHandlers.js
+++ b/web/src/components/import/DataSheetEventHandlers.js
@@ -116,9 +116,14 @@ class DataSheetEventHandlers {
     const row = params.context.highlighted[params.rowIndex];
     if (row && row[params.colDef.field]) return {backgroundColor: yellow[100]};
 
+
     // Cell validations
     if (params.context.cellValidations) {
       const row = params.data.id;
+
+      if(params.context.cellValidations[row]?.id?.levelId === 'DUPLICATE')
+        return {backgroundColor: blue[100]};
+
       const field = params.colDef.field;
       const level = params.context.cellValidations[row]?.[field]?.levelId;
       switch (level) {
@@ -333,7 +338,7 @@ class DataSheetEventHandlers {
       const [cells] = e.api.getCellRanges();
       const row = e.api.getDisplayedRowAtIndex(cells.startRow.rowIndex);
       const data = e.context.rowData.find((d) => d.id == row.data.id);
-      const newId = +new Date().valueOf();
+      const newId = +((new Date().valueOf() + '').slice(-8));
       const posMap = e.context.rowData.map((r) => r.pos).sort((a, b) => a - b);
       const currentPosIdx = posMap.findIndex((p) => p == data.pos);
 
@@ -347,7 +352,8 @@ class DataSheetEventHandlers {
       eh.pushUndo(e.api, [{id: newId}]);
       e.context.rowData.push(newData);
       e.api.setRowData(e.context.rowData);
-      e.context.rowPos = e.context.rowData.map((r) => r.pos).sort((a, b) => a - b);
+      const positions = e.context.rowData.map((r) => r.pos).sort((a, b) => a - b);
+      e.context.rowPos = positions.map((p) => e.context.rowData.find(r => r.pos === p).id);
 
       const filterModel = e.api.getFilterModel();
       const isFiltered = Object.getOwnPropertyNames(filterModel).length > 0;


### PR DESCRIPTION
Implements the remaining validations needed for single-survey corrections.

Refactors validation methods from the `ValidationProcess` class into `SurveyValidation`, `SiteValidation` and `SpeciesFormatting` services.

---

Checks excluded from corrections:
- Survey Group (since this is single-survey only)
- Buddy (since buddy is not ingested and can't be corrected)
- Total (since the checksum is present for Excel sheets only)

Validations refactored and added to corrections:

Block checks
- M1, M2 (and M3 if ATRC) are present
- M1, M2 each have B1, B2 (and M3 has B0 if ATRC)
- M0 has B0, B1 or B2

Survey checks
- Survey Is New (and fail if survey ID doesn't match the survey being corrected
- Survey Group (available but disabled since it will always fail for a single survey)
- SurveyTransects (survey has 1,2,3,4 survey numbers)
- M3 checks that transect sums to 50 but M3 is less than 50
- ATRC / RLS Future Survey Rule / Surveys Too Old
- Survey not more than 10km from Site
 
Species checks
- Inverts are zero for M3, M4, M5
- Species are valid for method
- Abundance exceeds MaxAbundance
- Observations are under Lmax and within L5/95 
- 'Survey Not Done' / 'No Species Found' / Debris has Value/Total/Inverts of 0 or 1

Other checks
- Duplicate Rows check
- Row contains no measurements
- Row has no data and no value recorded for inverts
- Row has no data and but not flagged as 'Survey Not Done' or 'No Species Found'