### PR TITLE
Add PQ diver to survey corrections sheet

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -208,7 +208,7 @@ public class CorrectionController {
             {
                 put("block", "Block is not an integer");
                 put("date", "Date format not valid");
-                put("depth", "Depth is not an integer");
+                put("depth", "Depth is not a decimal");
                 put("direction", "Direction is not valid");
                 put("diver", "Diver does not exist");
                 put("latitude", "Latitude is not a decimal");

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowMapperConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/StagedRowMapperConfig.java
@@ -35,6 +35,7 @@ public class StagedRowMapperConfig {
         modelMapper.typeMap(StagedRowFormatted.class, StagedRow.class)
                 .addMappings(mapper -> mapper.map(StagedRowFormatted::getMethod, StagedRow::setMethod))
                 .addMappings(mapper -> mapper.map(StagedRowFormatted::getBlock, StagedRow::setBlock))
+                .addMappings(mapper -> mapper.map(StagedRowFormatted::getDecimalDepth, StagedRow::setDepth))
                 .addMappings(mapper -> mapper.map(src -> src.getDiver().getInitials(), StagedRow::setDiver))
                 .addMappings(mapper -> mapper.using(dateMapper)
                         .map(StagedRowFormatted::getDate, StagedRow::setDate))

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
@@ -17,7 +17,7 @@ public interface CorrectionRowRepository
 
     @Query(value = "SELECT" +
     " c.survey_id AS surveyId, c.survey_num AS surveyNum, c.diver_id AS diverId," +
-    " c.initials AS diver, c.pq_initials AS pqDiver, c.site_code AS siteCode, c.depth, TO_CHAR(c.survey_date, 'dd/MM/yyyy') AS DATE," +
+    " c.initials AS diver, c.pq_initials AS pqDiver, c.site_code AS siteCode, CAST(c.depth AS text) || '.' || CAST(c.survey_num AS text) AS depth, TO_CHAR(c.survey_date, 'dd/MM/yyyy') AS DATE," +
     " TO_CHAR(c.survey_time, 'HH24:MI') AS time, c.visibility AS vis, c.direction, c.latitude, c.longitude," +
     " c.observable_item_id AS observableItemId, c.observable_item_name AS species, c.letter_code AS code," +
     " c.method_id AS method, c.block_num as block," +

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
@@ -17,7 +17,7 @@ public interface CorrectionRowRepository
 
     @Query(value = "SELECT" +
     " c.survey_id AS surveyId, c.survey_num AS surveyNum, c.diver_id AS diverId," +
-    " c.initials AS diver, c.site_code AS siteCode, c.depth, TO_CHAR(c.survey_date, 'dd/MM/yyyy') AS DATE," +
+    " c.initials AS diver, c.pq_initials AS pqDiver, c.site_code AS siteCode, c.depth, TO_CHAR(c.survey_date, 'dd/MM/yyyy') AS DATE," +
     " TO_CHAR(c.survey_time, 'HH24:MI') AS time, c.visibility AS vis, c.direction, c.latitude, c.longitude," +
     " c.observable_item_id AS observableItemId, c.observable_item_name AS species, c.letter_code AS code," +
     " c.method_id AS method, c.block_num as block," +
@@ -25,7 +25,7 @@ public interface CorrectionRowRepository
     " (CASE WHEN c.letter_code = 'SND' THEN '' ELSE CAST(jsonb_agg(c.observation_id) AS text) END) AS observationIds," +
     " CAST(jsonb_object_agg(c.seq_no, c.measure_sum) AS TEXT) AS measureJson" +
     " FROM" +
-    " (SELECT o.observation_id, s.survey_id, s.survey_num, o.diver_id, d.initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
+    " (SELECT o.observation_id, s.survey_id, s.survey_num, o.diver_id, d.initials, e.initials as pq_initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
     "   s.visibility, s.direction, s.latitude, s.longitude, o.observable_item_id," +
     "   COALESCE(i.observable_item_name, 'Survey Not Done') AS observable_item_name," +
     "   CASE WHEN o.observation_id IS NULL THEN 'SND' ELSE i.letter_code END," +
@@ -33,15 +33,16 @@ public interface CorrectionRowRepository
     "   AS measure_sum, mt.measure_type_id FROM nrmn.survey_method m" +
     "   LEFT JOIN nrmn.observation o ON o.survey_method_id = m.survey_method_id" +
     "   LEFT JOIN nrmn.observable_item_ref i ON o.observable_item_id = i.observable_item_id" +
-    "   LEFT JOIN nrmn.diver_ref d ON o.diver_id = d.diver_id" +
+    "   LEFT JOIN nrmn.diver_ref d ON o.diver_id    = d.diver_id" +
     "   LEFT JOIN nrmn.survey s ON s.survey_id = m.survey_id JOIN nrmn.site_ref t ON s.site_id = t.site_id" +
+    "   LEFT JOIN nrmn.diver_ref e ON s.pq_diver_id = e.diver_id" +
     "   LEFT JOIN nrmn.measure_ref r ON r.measure_id = o.measure_id" +
     "   LEFT JOIN nrmn.measure_type_ref mt ON r.measure_type_id = mt.measure_type_id" +
     "   WHERE m.survey_id = :surveyId" +
-    "   GROUP BY o.observation_id, s.survey_id, s.survey_num, o.diver_id, d.initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
+    "   GROUP BY o.observation_id, s.survey_id, s.survey_num, o.diver_id, d.initials, e.initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
     "   s.visibility, s.direction, s.latitude, s.longitude, r.seq_no, o.observable_item_id, i.observable_item_name, i.letter_code," +
     "   m.method_id, m.block_num, o.measure_id, mt.measure_type_id) c" +
-    " GROUP BY c.survey_id, c.survey_num, c.diver_id, c.initials, c.site_code, c.depth, c.survey_date, c.survey_time, c.visibility," +
+    " GROUP BY c.survey_id, c.survey_num, c.diver_id, c.initials, c.pq_initials, c.site_code, c.depth, c.survey_date, c.survey_time, c.visibility," +
     " c.direction, c.latitude, c.longitude, c.observable_item_id, c.observable_item_name, c.letter_code, c.method_id, c.block_num, c.measure_type_id" +
     " ORDER BY c.method_id, c.block_num;", nativeQuery = true)
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRowDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRowDto.java
@@ -1,5 +1,7 @@
 package au.org.aodn.nrmn.restapi.dto.correction;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public interface CorrectionRowDto {
     String getObservationIds();
 
@@ -10,6 +12,9 @@ public interface CorrectionRowDto {
     Integer getDiverId();
 
     String getDiver();
+
+    @JsonProperty(value = "P-Qs")
+    String getPqDiver();
 
     String getSiteCode();
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRowDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRowDto.java
@@ -7,8 +7,6 @@ public interface CorrectionRowDto {
 
     Integer getSurveyId();
     
-    Integer getSurveyNum();
-
     Integer getDiverId();
 
     String getDiver();
@@ -36,7 +34,7 @@ public interface CorrectionRowDto {
 
     String getBlock();
 
-    Integer getDepth();
+    String getDepth();
 
     String getDate();
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/StagedRowFormatted.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/StagedRowFormatted.java
@@ -109,8 +109,13 @@ public class StagedRowFormatted {
         return ref.getSurveyGroup();
     }
 
+    public String getDecimalDepth() {
+        return String.format("%s.%d", getDepth(), getSurveyNum());
+    }
+
+
     public String getDecimalSurvey() {
-        return String.format("[%s, %s, %s.%d]", getRef().getSiteCode(),  getDate(), getDepth(), getSurveyNum());
+        return String.format("[%s, %s, %s]", getRef().getSiteCode(),  getDate(), getDecimalDepth());
     }
 
     public Integer observationTotal() { 

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -105,6 +105,7 @@ const SurveyCorrect = () => {
       {field: 'surveyId', label: 'Survey'},
       {field: 'diverId', label: 'Diver ID', hide: true},
       {field: 'diver', label: 'Diver'},
+      {field: 'P-Qs', label: 'PQ Diver'},
       {field: 'siteCode', label: 'Site Code'},
       {field: 'depth', label: 'Depth'},
       {field: 'date', label: 'Survey Date'},

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -102,13 +102,13 @@ const SurveyCorrect = () => {
     return [
       {field: 'pos', label: '', editable: false, hide: true, sort: 'asc'},
       {field: 'id', label: '', editable: false, hide: true},
-      {field: 'surveyId', label: 'Survey'},
+      {field: 'surveyId', label: 'Survey', editable: false},
       {field: 'diverId', label: 'Diver ID', hide: true},
       {field: 'diver', label: 'Diver'},
       {field: 'P-Qs', label: 'PQ Diver'},
-      {field: 'siteCode', label: 'Site Code'},
-      {field: 'depth', label: 'Depth'},
-      {field: 'date', label: 'Survey Date'},
+      {field: 'siteCode', label: 'Site Code', editable: false},
+      {field: 'depth', label: 'Depth', editable: false},
+      {field: 'date', label: 'Survey Date', editable: false},
       {field: 'time', label: 'Survey Time'},
       {field: 'vis', label: 'Visibility'},
       {field: 'direction', label: 'Direction'},
@@ -293,7 +293,7 @@ const SurveyCorrect = () => {
         <Box flexGrow={1}>
           <Typography variant="h6">
             Correct Survey{' '}
-            {rowData && '[' + rowData[0].siteCode + ', ' + rowData[0].date + ', ' + rowData[0].depth + '.' + rowData[0].surveyNum + '] ' + validationMode.programValidation + ' ' + (validationMode.isExtended ? 'Extended' : '')}
+            {rowData && '[' + rowData[0].siteCode + ', ' + rowData[0].date + ', ' + rowData[0].depth + '] ' + validationMode.programValidation + ' ' + (validationMode.isExtended ? 'Extended' : '')}
           </Typography>
         </Box>
         <Box m={1} ml={0}>


### PR DESCRIPTION
Add PQ diver to survey corrections sheet
Use the 'decimal depth' combining depth and survey number so the survey transect check can be reused.
Make the site/date/depth/id read-only until multiple surveys can be corrected.