### PR TITLE
summary panel: skip mm header lookup if no column

### DIFF
--- a/web/src/components/data-entities/survey/panel/SummaryPanel.js
+++ b/web/src/components/data-entities/survey/panel/SummaryPanel.js
@@ -74,7 +74,7 @@ const SummaryPanel = ({api, context}) => {
                   }
                 >
                   {m.description?.map((d) => {
-                    const mmHeader = mm.find((m) => m.field === d.columnName.replace('measurements.', ''));
+                    const mmHeader = mm.find((m) => d.columnName && m.field === d.columnName.replace('measurements.', ''));
                     const label = mmHeader ? `${d.isInvertSize ? mmHeader.invertSize : mmHeader.fishSize}cm` : d.columnName;
                     return (
                       <TreeItem


### PR DESCRIPTION
Fixes issue where changing a cloned row to a different survey number causes validation to fail.