### PR TITLE
Multiple Survey Corrections Feature

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -365,7 +365,7 @@ public class CorrectionController {
             }
 
             surveyCorrectionService.correctSurvey(job, surveyIds, mappedRows);
-            // materializedViewService.refreshAllMaterializedViews();
+            materializedViewService.refreshAllMaterializedViews();
 
         } catch (Exception e) {
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import au.org.aodn.nrmn.restapi.controller.mapping.StagedRowMapperConfig;
@@ -247,15 +248,17 @@ public class CorrectionController {
         return validation;
     }
 
-    @GetMapping(path = "correct/{survey_id}")
+    @GetMapping(path = "correct")
     @Operation(security = { @SecurityRequirement(name = "bearer-key") })
-    public ResponseEntity<?> getSurveyCorrection(@PathVariable("survey_id") Integer surveyId) {
-        var rows = correctionRowRepository.findRowsBySurveyId(surveyId);
+    public ResponseEntity<?> getSurveyCorrections(@RequestParam("surveyIds") List<Integer> surveyIds) {
+        var rows = correctionRowRepository.findRowsBySurveyIds(surveyIds);
         var exists = rows != null && rows.size() > 0;
         var bodyDto = new CorrectionRowsDto();
         bodyDto.setRows(rows);
-        var survey = surveyRepository.getReferenceById(surveyId);
-        bodyDto.setProgramValidation(ProgramValidation.fromProgram(survey.getProgram()));
+        // HACK: just to get it working
+        bodyDto.setProgramValidation(ProgramValidation.NONE);
+        // var survey = surveyRepository.getReferenceById(surveyId);
+        // bodyDto.setProgramValidation(ProgramValidation.fromProgram(survey.getProgram()));
         return exists ? ResponseEntity.ok(bodyDto) : ResponseEntity.notFound().build();
     }
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -365,7 +365,7 @@ public class CorrectionController {
             }
 
             surveyCorrectionService.correctSurvey(job, surveyIds, mappedRows);
-            materializedViewService.refreshAllMaterializedViews();
+            // materializedViewService.refreshAllMaterializedViews();
 
         } catch (Exception e) {
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -341,7 +341,7 @@ public class CorrectionController {
 
         var job = StagedJob.builder()
                 .source(SourceJobType.CORRECTION)
-                .reference("Correct Survey " + survey)
+                .reference("Correct " + survey)
                 .status(StatusJobType.CORRECTED)
                 .program(program)
                 .creator(user.get())
@@ -364,7 +364,7 @@ public class CorrectionController {
                 return ResponseEntity.ok().body(result);
             }
 
-            // surveyCorrectionService.correctSurvey(job, survey, mappedRows);
+            surveyCorrectionService.correctSurvey(job, surveyIds, mappedRows);
             materializedViewService.refreshAllMaterializedViews();
 
         } catch (Exception e) {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SurveyController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SurveyController.java
@@ -31,6 +31,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import au.org.aodn.nrmn.restapi.dto.survey.SurveyDto;
+import au.org.aodn.nrmn.restapi.service.MaterializedViewService;
 import au.org.aodn.nrmn.restapi.service.SurveyEditService;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -52,6 +53,9 @@ public class SurveyController {
 
     @Autowired
     private SurveyEditService surveyEditService;
+
+    @Autowired
+    private MaterializedViewService materializedViewService;
 
     @Autowired
     private ModelMapper mapper;
@@ -168,6 +172,7 @@ public class SurveyController {
         Survey survey = surveyEditService.updateSurvey(surveyDto);
 
         Survey persistedSurvey = surveyRepository.save(survey);
+        materializedViewService.refreshAllMaterializedViews();
         SurveyDto updatedSurveyDto = mapper.map(persistedSurvey, SurveyDto.class);
         return ResponseEntity.ok(updatedSurveyDto);
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/Observation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/Observation.java
@@ -36,7 +36,7 @@ import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
 public class Observation {
     @Id
     @SequenceGenerator(name = "observation_observation_id", sequenceName = "observation_observation_id",
-     allocationSize = 1)
+     allocationSize = 100)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator="observation_observation_id")
     @Column(name = "observation_id", unique = true, updatable = false, nullable = false)
     private Integer observationId;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/SurveyMethodEntity.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/SurveyMethodEntity.java
@@ -30,7 +30,7 @@ import lombok.ToString;
 public class SurveyMethodEntity {
     @Id
     @SequenceGenerator(name = "survey_method_survey_method_id", sequenceName = "survey_method_survey_method_id",
-        allocationSize = 1)
+        allocationSize = 100)
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator="survey_method_survey_method_id")
     @Column(name = "survey_method_id", unique = true, updatable = false, nullable = false)
     private Integer surveyMethodId;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
@@ -9,11 +9,15 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import au.org.aodn.nrmn.restapi.data.model.Observation;
+import au.org.aodn.nrmn.restapi.data.model.Program;
 import au.org.aodn.nrmn.restapi.dto.correction.CorrectionRowDto;
 
 @Repository
 public interface CorrectionRowRepository
         extends JpaRepository<Observation, Long>, JpaSpecificationExecutor<Observation> {
+
+    @Query("SELECT DISTINCT s.program FROM Survey s where s.id IN :surveyIds")
+    List<Program> findProgramsBySurveyIds(@Param("surveyIds") List<Integer> surveyIds);
 
     @Query(value = "SELECT" +
     " c.survey_id AS surveyId, c.survey_num AS surveyNum, c.diver_id AS diverId," +
@@ -44,7 +48,7 @@ public interface CorrectionRowRepository
     "   m.method_id, m.block_num, o.measure_id, mt.measure_type_id) c" +
     " GROUP BY c.survey_id, c.survey_num, c.diver_id, c.initials, c.pq_initials, c.site_code, c.depth, c.survey_date, c.survey_time, c.visibility," +
     " c.direction, c.latitude, c.longitude, c.observable_item_id, c.observable_item_name, c.letter_code, c.method_id, c.block_num, c.measure_type_id" +
-    " ORDER BY c.method_id, c.block_num;", nativeQuery = true)
+    " ORDER BY c.survey_id, c.method_id, c.block_num;", nativeQuery = true)
     
     List<CorrectionRowDto> findRowsBySurveyIds(@Param("surveyIds") List<Integer> surveyIds);
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
@@ -19,36 +19,41 @@ public interface CorrectionRowRepository
     @Query("SELECT DISTINCT s.program FROM Survey s where s.id IN :surveyIds")
     List<Program> findProgramsBySurveyIds(@Param("surveyIds") List<Integer> surveyIds);
 
-    @Query(value = "SELECT" +
-    " c.survey_id AS surveyId, c.survey_num AS surveyNum, c.diver_id AS diverId," +
-    " c.initials AS diver, c.pq_initials AS pqDiver, c.site_code AS siteCode, CAST(c.depth AS text) || '.' || CAST(c.survey_num AS text) AS depth, TO_CHAR(c.survey_date, 'dd/MM/yyyy') AS DATE," +
-    " TO_CHAR(c.survey_time, 'HH24:MI') AS time, c.visibility AS vis, c.direction, c.latitude, c.longitude," +
-    " c.observable_item_id AS observableItemId, c.observable_item_name AS species, c.letter_code AS code," +
-    " c.method_id AS method, c.block_num as block," +
-    " (CASE WHEN measure_type_id = 4 THEN 'Yes' ELSE 'No' END) AS isInvertSizing," +
-    " (CASE WHEN c.letter_code = 'SND' THEN '' ELSE CAST(jsonb_agg(c.observation_id) AS text) END) AS observationIds," +
-    " CAST(jsonb_object_agg(c.seq_no, c.measure_sum) AS TEXT) AS measureJson" +
-    " FROM" +
-    " (SELECT o.observation_id, s.survey_id, s.survey_num, o.diver_id, d.initials, e.initials as pq_initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
-    "   s.visibility, s.direction, s.latitude, s.longitude, o.observable_item_id," +
-    "   COALESCE(i.observable_item_name, 'Survey Not Done') AS observable_item_name," +
-    "   CASE WHEN o.observation_id IS NULL THEN 'SND' ELSE i.letter_code END," +
-    "   m.method_id, COALESCE(m.block_num, 0) as block_num, o.measure_id, COALESCE(r.seq_no, 0) AS seq_no, COALESCE(SUM(o.measure_value), 0)" +
-    "   AS measure_sum, mt.measure_type_id FROM nrmn.survey_method m" +
-    "   LEFT JOIN nrmn.observation o ON o.survey_method_id = m.survey_method_id" +
-    "   LEFT JOIN nrmn.observable_item_ref i ON o.observable_item_id = i.observable_item_id" +
-    "   LEFT JOIN nrmn.diver_ref d ON o.diver_id    = d.diver_id" +
-    "   LEFT JOIN nrmn.survey s ON s.survey_id = m.survey_id JOIN nrmn.site_ref t ON s.site_id = t.site_id" +
-    "   LEFT JOIN nrmn.diver_ref e ON s.pq_diver_id = e.diver_id" +
-    "   LEFT JOIN nrmn.measure_ref r ON r.measure_id = o.measure_id" +
-    "   LEFT JOIN nrmn.measure_type_ref mt ON r.measure_type_id = mt.measure_type_id" +
-    "   WHERE m.survey_id IN :surveyIds" +
-    "   GROUP BY o.observation_id, s.survey_id, s.survey_num, o.diver_id, d.initials, e.initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
-    "   s.visibility, s.direction, s.latitude, s.longitude, r.seq_no, o.observable_item_id, i.observable_item_name, i.letter_code," +
-    "   m.method_id, m.block_num, o.measure_id, mt.measure_type_id) c" +
-    " GROUP BY c.survey_id, c.survey_num, c.diver_id, c.initials, c.pq_initials, c.site_code, c.depth, c.survey_date, c.survey_time, c.visibility," +
-    " c.direction, c.latitude, c.longitude, c.observable_item_id, c.observable_item_name, c.letter_code, c.method_id, c.block_num, c.measure_type_id" +
-    " ORDER BY c.survey_id, c.method_id, c.block_num;", nativeQuery = true)
+    @Query(value = "" +
+    "SELECT c.survey_id AS surveyId, c.survey_num AS surveyNum, c.diver_id AS diverId, c.initials AS diver, c.pq_initials AS pqDiver," +
+    "c.site_code AS siteCode, CAST(c.depth AS text) || '.' || CAST(c.survey_num AS text) AS depth, TO_CHAR(c.survey_date, 'dd/MM/yyyy') AS DATE," +
+    "TO_CHAR(c.survey_time, 'HH24:MI') AS time, c.visibility AS vis, c.direction, c.latitude, c.longitude," +
+    "c.observable_item_id AS observableItemId, c.observable_item_name AS species, c.letter_code AS code," +
+    "c.method_id AS method, c.block_num as block," +
+    "(CASE WHEN measure_type_id = 4 THEN 'Yes' ELSE 'No' END) AS isInvertSizing," +
+    "(CASE WHEN c.letter_code = 'SND' THEN '' ELSE c.observation_ids END) AS observationIds," +
+    "CAST(jsonb_object_agg(c.seq_no, c.measure_sum) AS TEXT) AS measureJson "+
+	"FROM " +
+	"(SELECT CAST(jsonb_agg(o.observation_id) AS TEXT) as observation_ids," +
+    "COALESCE(i.observable_item_name, 'Survey Not Done') AS observable_item_name," +
+    "COALESCE(m.block_num, 0) as block_num, " +
+	"COALESCE(r.seq_no, 0) AS seq_no, " +
+	"COALESCE(SUM(o.measure_value), 0) as measure_sum," +
+	"CASE WHEN o.observable_item_id IS NULL THEN 'SND' ELSE i.letter_code END AS letter_code," +
+	"m.method_id, o.measure_id," +
+	"s.survey_id, o.diver_id, d.initials, s.survey_num, e.initials as pq_initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
+    "s.visibility, s.direction, s.latitude, s.longitude, o.observable_item_id," +
+	"mt.measure_type_id FROM nrmn.survey_method m " +
+    "LEFT JOIN nrmn.observation o ON o.survey_method_id = m.survey_method_id " +
+    "LEFT JOIN nrmn.observable_item_ref i ON o.observable_item_id = i.observable_item_id " +
+    "LEFT JOIN nrmn.diver_ref d ON o.diver_id    = d.diver_id " +
+    "LEFT JOIN nrmn.survey s ON s.survey_id = m.survey_id JOIN nrmn.site_ref t ON s.site_id = t.site_id " +
+    "LEFT JOIN nrmn.diver_ref e ON s.pq_diver_id = e.diver_id "+
+    "LEFT JOIN nrmn.measure_ref r ON r.measure_id = o.measure_id " +
+    "LEFT JOIN nrmn.measure_type_ref mt ON r.measure_type_id = mt.measure_type_id "+
+    "WHERE m.survey_id IN :surveyIds " +
+	"GROUP BY m.method_id, m.block_num, o.measure_id, seq_no, mt.measure_type_id," +
+	"s.survey_id, o.diver_id, d.initials, pq_initials, s.survey_num, e.initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
+	"s.visibility, s.direction, s.latitude, s.longitude, o.observable_item_id, observable_item_name, letter_code) c " +
+    "GROUP BY c.survey_id, c.survey_num, c.diver_id, c.initials, c.pq_initials, c.site_code, c.depth, c.survey_date, c.survey_time, c.visibility," +
+    "c.direction, c.latitude, c.longitude, c.observable_item_id, c.observable_item_name, c.letter_code, c.observation_ids, c.method_id, c.block_num, c.measure_type_id " +
+    "ORDER BY c.survey_id, c.method_id, c.block_num" + 
+     "", nativeQuery = true)
     
     List<CorrectionRowDto> findRowsBySurveyIds(@Param("surveyIds") List<Integer> surveyIds);
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
@@ -21,9 +21,9 @@ public interface CorrectionRowRepository
 
     @Query(value = "" +
     "SELECT c.survey_id AS surveyId, c.survey_num AS surveyNum, c.diver_id AS diverId, c.initials AS diver, c.pq_initials AS pqDiver," +
-    "c.site_code AS siteCode, CAST(c.depth AS text) || '.' || CAST(c.survey_num AS text) AS depth, TO_CHAR(c.survey_date, 'dd/MM/yyyy') AS DATE," +
+    "c.site_code AS siteCode, c.site_name AS siteName, CAST(c.depth AS text) || '.' || CAST(c.survey_num AS text) AS depth, TO_CHAR(c.survey_date, 'dd/MM/yyyy') AS DATE," +
     "TO_CHAR(c.survey_time, 'HH24:MI') AS time, c.visibility AS vis, c.direction, c.latitude, c.longitude," +
-    "c.observable_item_id AS observableItemId, c.observable_item_name AS species, c.letter_code AS code," +
+    "c.observable_item_name AS species, c.common_name as commonName, LOWER(c.letter_code) AS code," +
     "c.method_id AS method, c.block_num as block," +
     "(CASE WHEN measure_type_id = 4 THEN 'Yes' ELSE 'No' END) AS isInvertSizing," +
     "(CASE WHEN c.letter_code = 'SND' THEN '' ELSE c.observation_ids END) AS observationIds," +
@@ -36,8 +36,8 @@ public interface CorrectionRowRepository
 	"COALESCE(SUM(o.measure_value), 0) as measure_sum," +
 	"CASE WHEN o.observable_item_id IS NULL THEN 'SND' ELSE i.letter_code END AS letter_code," +
 	"m.method_id, o.measure_id," +
-	"s.survey_id, o.diver_id, d.initials, s.survey_num, e.initials as pq_initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
-    "s.visibility, s.direction, s.latitude, s.longitude, o.observable_item_id," +
+	"s.survey_id, o.diver_id, d.initials, s.survey_num, e.initials as pq_initials, t.site_code, t.site_name, s.depth, s.survey_date, s.survey_time," +
+    "s.visibility, s.direction, s.latitude, s.longitude, i.common_name," +
 	"mt.measure_type_id FROM nrmn.survey_method m " +
     "LEFT JOIN nrmn.observation o ON o.survey_method_id = m.survey_method_id " +
     "LEFT JOIN nrmn.observable_item_ref i ON o.observable_item_id = i.observable_item_id " +
@@ -48,10 +48,10 @@ public interface CorrectionRowRepository
     "LEFT JOIN nrmn.measure_type_ref mt ON r.measure_type_id = mt.measure_type_id "+
     "WHERE m.survey_id IN :surveyIds " +
 	"GROUP BY m.method_id, m.block_num, o.measure_id, seq_no, mt.measure_type_id," +
-	"s.survey_id, o.diver_id, d.initials, pq_initials, s.survey_num, e.initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
-	"s.visibility, s.direction, s.latitude, s.longitude, o.observable_item_id, observable_item_name, letter_code) c " +
-    "GROUP BY c.survey_id, c.survey_num, c.diver_id, c.initials, c.pq_initials, c.site_code, c.depth, c.survey_date, c.survey_time, c.visibility," +
-    "c.direction, c.latitude, c.longitude, c.observable_item_id, c.observable_item_name, c.letter_code, c.observation_ids, c.method_id, c.block_num, c.measure_type_id " +
+	"s.survey_id, o.diver_id, d.initials, pq_initials, s.survey_num, e.initials, t.site_code, t.site_name, s.depth, s.survey_date, s.survey_time," +
+	"s.visibility, s.direction, s.latitude, s.longitude, o.observable_item_id, observable_item_name, i.common_name, letter_code) c " +
+    "GROUP BY c.survey_id, c.survey_num, c.diver_id, c.initials, c.pq_initials, c.site_code, c.site_name, c.depth, c.survey_date, c.survey_time, c.visibility," +
+    "c.direction, c.latitude, c.longitude, c.observable_item_name, c.common_name, c.letter_code, c.observation_ids, c.method_id, c.block_num, c.measure_type_id " +
     "ORDER BY c.survey_id, c.method_id, c.block_num" + 
      "", nativeQuery = true)
     

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/CorrectionRowRepository.java
@@ -38,14 +38,13 @@ public interface CorrectionRowRepository
     "   LEFT JOIN nrmn.diver_ref e ON s.pq_diver_id = e.diver_id" +
     "   LEFT JOIN nrmn.measure_ref r ON r.measure_id = o.measure_id" +
     "   LEFT JOIN nrmn.measure_type_ref mt ON r.measure_type_id = mt.measure_type_id" +
-    "   WHERE m.survey_id = :surveyId" +
+    "   WHERE m.survey_id IN :surveyIds" +
     "   GROUP BY o.observation_id, s.survey_id, s.survey_num, o.diver_id, d.initials, e.initials, t.site_code, s.depth, s.survey_date, s.survey_time," +
     "   s.visibility, s.direction, s.latitude, s.longitude, r.seq_no, o.observable_item_id, i.observable_item_name, i.letter_code," +
     "   m.method_id, m.block_num, o.measure_id, mt.measure_type_id) c" +
     " GROUP BY c.survey_id, c.survey_num, c.diver_id, c.initials, c.pq_initials, c.site_code, c.depth, c.survey_date, c.survey_time, c.visibility," +
     " c.direction, c.latitude, c.longitude, c.observable_item_id, c.observable_item_name, c.letter_code, c.method_id, c.block_num, c.measure_type_id" +
     " ORDER BY c.method_id, c.block_num;", nativeQuery = true)
-
-            
-    List<CorrectionRowDto> findRowsBySurveyId(@Param("surveyId") Integer surveyId);
+    
+    List<CorrectionRowDto> findRowsBySurveyIds(@Param("surveyIds") List<Integer> surveyIds);
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/MeasureRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/MeasureRepository.java
@@ -2,20 +2,24 @@ package au.org.aodn.nrmn.restapi.data.repository;
 
 import java.util.Optional;
 
-import org.springframework.cache.annotation.Cacheable;
+import javax.persistence.QueryHint;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import au.org.aodn.nrmn.restapi.data.model.Measure;
 
+import static org.hibernate.jpa.QueryHints.HINT_CACHEABLE;
+
 @Repository
 public interface MeasureRepository extends JpaRepository<Measure, Integer>, JpaSpecificationExecutor<Measure> {
 
     @Query("SELECT m FROM Measure m WHERE m.measureType.measureTypeId = :measureTypeId and m.seqNo = :seqNo")
-    @Cacheable("measures")
+    @QueryHints({@QueryHint(name = HINT_CACHEABLE, value = "true")})
     Optional<Measure> findByMeasureTypeIdAndSeqNo(@Param("measureTypeId") Integer measureTypeId,
                                                   @Param("seqNo") Integer seqNo);
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/SurveyMethodRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/SurveyMethodRepository.java
@@ -45,4 +45,9 @@ public interface SurveyMethodRepository extends JpaRepository<SurveyMethodEntity
     @Transactional
     @Query("DELETE FROM SurveyMethodEntity WHERE survey_id = :surveyId")
     void deleteForSurveyId(@Param("surveyId") Integer surveyId);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM SurveyMethodEntity WHERE survey_id IN :surveyId")
+    void deleteForSurveyIds(@Param("surveyId") List<Integer> surveyIds);
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRequestBodyDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRequestBodyDto.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class CorrectionRequestBodyDto {
-    private Boolean isExtended;
     private Integer programId;
+    private Boolean isExtended;
+    private Boolean isMultiple;
     private Collection<StagedRow> rows;
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRequestBodyDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRequestBodyDto.java
@@ -1,16 +1,15 @@
 package au.org.aodn.nrmn.restapi.dto.correction;
 
+import java.util.Collection;
+
 import au.org.aodn.nrmn.restapi.data.model.StagedRow;
-import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.util.Collection;
 
 @Data
 @NoArgsConstructor
 public class CorrectionRequestBodyDto {
     private Boolean isExtended;
-    private ProgramValidation programValidation;
+    private Integer programId;
     private Collection<StagedRow> rows;
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRowDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRowDto.java
@@ -14,6 +14,8 @@ public interface CorrectionRowDto {
 
     String getSiteCode();
 
+    String getSiteName();
+
     String getDirection();
 
     String getLatitude();
@@ -22,9 +24,9 @@ public interface CorrectionRowDto {
 
     String getIsInvertSizing();
 
-    String getObservableItemId();
-
     String getSpecies();
+
+    String getCommonName();
 
     String getCode();
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRowsDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/CorrectionRowsDto.java
@@ -5,11 +5,11 @@ import lombok.NoArgsConstructor;
 
 import java.util.Collection;
 
-import au.org.aodn.nrmn.restapi.enums.ProgramValidation;
-
 @Data
 @NoArgsConstructor
 public class CorrectionRowsDto {
-    ProgramValidation programValidation;
+    Integer programId;
+    String programName;
+    Collection<Integer> surveyIds;
     Collection<CorrectionRowDto> rows;
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/enums/MeasureType.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/enums/MeasureType.java
@@ -1,11 +1,26 @@
 package au.org.aodn.nrmn.restapi.enums;
 
 public class MeasureType {
-    public static final int FishSizeClass = 1;
-    public static final int InSituQuadrat = 2;
-    public static final int MacrocystisBlock = 3;
-    public static final int InvertSizeClass = 4;
-    public static final int SingleItem = 5;
-    public static final int Absence = 6;
-    public static final int LimpetQuadrat = 7;
+    public static final Integer FishSizeClass = 1;
+    public static final Integer InSituQuadrat = 2;
+    public static final Integer MacrocystisBlock = 3;
+    public static final Integer InvertSizeClass = 4;
+    public static final Integer SingleItem = 5;
+    public static final Integer Absence = 6;
+    public static final Integer LimpetQuadrat = 7;
+
+    public static Integer fromMethodId(Integer methodId) {
+        switch (methodId) {
+            case SurveyMethod.M3:
+                return InSituQuadrat;
+            case SurveyMethod.M4:
+                return MeasureType.MacrocystisBlock;
+            case SurveyMethod.M5:
+                return MeasureType.LimpetQuadrat;
+            case SurveyMethod.M12:
+                return MeasureType.SingleItem;
+            default:
+                return MeasureType.FishSizeClass;
+        }
+    }
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
@@ -8,13 +8,11 @@ import java.util.OptionalDouble;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import au.org.aodn.nrmn.restapi.data.model.Method;
 import au.org.aodn.nrmn.restapi.data.model.Observation;
 import au.org.aodn.nrmn.restapi.data.model.StagedJob;
 import au.org.aodn.nrmn.restapi.data.model.StagedJobLog;
@@ -139,6 +137,7 @@ public class SurveyCorrectionService {
         }
 
         for (var surveyId : surveyIds) {
+            messages.add("Correcting Survey ID: " + surveyId);
             messages.add("Delete Observation IDs: " + observationsForSurveySummary(surveyId));
 
             var survey = surveyRepository.findById(surveyId).orElse(null);
@@ -226,12 +225,12 @@ public class SurveyCorrectionService {
                     newIds.addAll(newObservations.stream().map(o -> o.getObservationId()).collect(Collectors.toList()));
                 }
 
-                messages.add("Insert Observation IDs: " + formatRange(newIds));
-                messages.add("Update Survey ID: " + surveyId);
+                messages.add("Insert Observation IDs for " + firstRow.getBlock() + " : " + method.getMethodId() + " " + formatRange(newIds));
             }
         }
 
         //TODO: set survey last updated and save new vis avg
+
         var details = messages.stream().collect(Collectors.joining("\n"));
         var log = StagedJobLog.builder().stagedJob(job).details(details).eventType(StagedJobEventType.CORRECTED);
         stagedJobLogRepository.save(log.build());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
@@ -3,12 +3,10 @@ package au.org.aodn.nrmn.restapi.service;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
+import java.util.OptionalDouble;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 import javax.transaction.Transactional;
@@ -16,8 +14,6 @@ import javax.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import au.org.aodn.nrmn.restapi.data.model.Diver;
-import au.org.aodn.nrmn.restapi.data.model.Measure;
 import au.org.aodn.nrmn.restapi.data.model.Method;
 import au.org.aodn.nrmn.restapi.data.model.Observation;
 import au.org.aodn.nrmn.restapi.data.model.StagedJob;
@@ -40,7 +36,6 @@ import au.org.aodn.nrmn.restapi.enums.StagedJobEventType;
 import au.org.aodn.nrmn.restapi.enums.StatusJobType;
 import au.org.aodn.nrmn.restapi.enums.SurveyMethod;
 import au.org.aodn.nrmn.restapi.service.validation.StagedRowFormatted;
-import lombok.Value;
 
 @Service
 @Transactional
@@ -79,90 +74,20 @@ public class SurveyCorrectionService {
     @Autowired
     StagedJobRepository jobRepository;
 
-    public void correctSurvey(StagedJob job, Survey survey, Collection<StagedRowFormatted> validatedRows) {
-        correctionTransaction(job, survey, validatedRows);
+    private List<Integer> speciesMethods = Arrays.asList(
+            SurveyMethod.M0,
+            SurveyMethod.M1,
+            SurveyMethod.M2,
+            SurveyMethod.M7,
+            SurveyMethod.M10,
+            SurveyMethod.M11);
+
+    public void correctSurvey(StagedJob job, List<Integer> surveyIds, Collection<StagedRowFormatted> validatedRows) {
+        correctionTransaction(job, surveyIds, validatedRows);
     }
 
     public void deleteSurvey(StagedJob job, Survey survey, Collection<StagedRowFormatted> validatedRows) {
         deletionTransaction(job, survey, validatedRows);
-    }
-
-    private SurveyMethodEntity getSurveyMethod(Survey survey, StagedRowFormatted stagedRow) {
-        var surveyNotDone = stagedRow.getRef().getSpecies().equalsIgnoreCase("Survey Not Done");
-        var method = entityManager.getReference(Method.class, stagedRow.getMethod());
-        var surveyMethod = SurveyMethodEntity.builder().survey(survey).method(method)
-                .blockNum(stagedRow.getBlock())
-                .surveyNotDone(surveyNotDone).build();
-        return surveyMethodRepository.save(surveyMethod);
-    }
-
-    private List<Observation> getObservations(SurveyMethodEntity surveyMethod, StagedRowFormatted stagedRow,
-            Boolean withExtendedSizing) {
-        if (!stagedRow.getSpecies().isPresent())
-            return Collections.emptyList();
-
-        Diver diver = stagedRow.getDiver();
-
-        Map<Integer, Integer> measures = stagedRow.getMeasureJson();
-
-        @Value
-        class MeasureValue {
-            private Integer seqNo;
-            private Integer measureValue;
-        }
-
-        Stream<MeasureValue> unsized = Stream.empty();
-
-        if (!stagedRow.getRef().getSpecies().equalsIgnoreCase("Survey Not Done") && stagedRow.getInverts() != null
-                && stagedRow.getInverts() > 0) {
-            unsized = Stream.of(new MeasureValue(0, stagedRow.getInverts()));
-        }
-
-        Stream<MeasureValue> sized = measures.entrySet().stream().map(m -> new MeasureValue(m.getKey(), m.getValue()));
-
-        List<Observation> observations = Stream.concat(unsized, sized).map(m -> {
-
-            Integer method = stagedRow.getMethod();
-
-            int measureTypeId = MeasureType.FishSizeClass;
-
-            if (IntStream
-                    .of(SurveyMethod.M0, SurveyMethod.M1, SurveyMethod.M2, SurveyMethod.M7, SurveyMethod.M10,
-                            SurveyMethod.M11)
-                    .anyMatch(x -> x == method)) {
-
-                if (withExtendedSizing && stagedRow.getIsInvertSizing())
-                    measureTypeId = MeasureType.InvertSizeClass;
-
-                if (stagedRow.getSpecies().get().getObsItemType()
-                        .getObsItemTypeId() == ObservableItemType.NoSpeciesFound)
-                    measureTypeId = MeasureType.Absence;
-
-            } else if (method == SurveyMethod.M3) {
-                measureTypeId = MeasureType.InSituQuadrat;
-            } else if (method == SurveyMethod.M4) {
-                measureTypeId = MeasureType.MacrocystisBlock;
-            } else if (method == SurveyMethod.M5) {
-                measureTypeId = MeasureType.LimpetQuadrat;
-            } else if (method == SurveyMethod.M12) {
-                measureTypeId = MeasureType.SingleItem;
-            }
-
-            Measure measure = measureRepository.findByMeasureTypeIdAndSeqNo(measureTypeId, m.getSeqNo()).orElse(null);
-
-            Observation observation = Observation.builder().diver(diver).surveyMethod(surveyMethod)
-                    .observableItem(stagedRow.getSpecies().get()).measure(measure).measureValue(m.getMeasureValue())
-                    .build();
-
-            return observation;
-        }).collect(Collectors.toList());
-
-        return observations;
-    }
-
-    private Map<String, List<StagedRowFormatted>> groupRowsByMethodBlock(List<StagedRowFormatted> surveyRows) {
-        return surveyRows.stream().filter(r -> r.getMethodBlock() != null)
-                .collect(Collectors.groupingBy(StagedRowFormatted::getMethodBlock));
     }
 
     private String formatRange(List<Integer> ids) {
@@ -200,38 +125,119 @@ public class SurveyCorrectionService {
         jobRepository.save(job);
     }
 
-    private void correctionTransaction(StagedJob job, Survey survey, Collection<StagedRowFormatted> validatedRows) {
+    private void correctionTransaction(StagedJob job, List<Integer> surveyIds,
+            Collection<StagedRowFormatted> validatedRows) {
 
-        var surveyIds = Arrays.<Integer>asList();
         var messages = new ArrayList<String>();
 
-        var surveyId = survey.getSurveyId();
-        messages.add("Delete Observation IDs: " + observationsForSurveySummary(surveyId));
-        surveyMethodRepository.deleteForSurveyId(surveyId);
+        var rowsGroupedBySurvey = validatedRows.stream()
+                .collect(Collectors.groupingBy(StagedRowFormatted::getSurveyId));
 
-        var rowsGroupedBySurvey = validatedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurvey));
+        // ASSERT: that the survey ids in the grouped rows match the list of survey ids
+        var groupedSurveyIds = rowsGroupedBySurvey.keySet().stream().map(l -> l.intValue())
+                .collect(Collectors.toList());
 
-        var newIds = new ArrayList<Integer>();
-        surveyIds = rowsGroupedBySurvey.values().stream().map(surveyRows -> {
-            groupRowsByMethodBlock(surveyRows).values().forEach(methodBlockRows -> {
-                var surveyMethod = getSurveyMethod(survey, methodBlockRows.get(0));
-                methodBlockRows.forEach(row -> {
-                    var newObservations = observationRepository.saveAll(
-                            getObservations(surveyMethod, row, job.getIsExtendedSize()));
+        if (!surveyIds.containsAll(groupedSurveyIds) || !groupedSurveyIds.containsAll(surveyIds)) {
+            throw new RuntimeException("Survey IDs in grouped rows do not match the list of survey IDs passed in");
+        }
+
+        for (var surveyId : surveyIds) {
+            messages.add("Delete Observation IDs: " + observationsForSurveySummary(surveyId));
+
+            var survey = surveyRepository.findById(surveyId).orElse(null);
+            surveyMethodRepository.deleteForSurveyId(surveyId);
+            var surveyRows = rowsGroupedBySurvey.get(surveyId.longValue());
+
+            var visAvg = surveyRows.stream().filter(r -> r.getVis().isPresent()).mapToDouble(r -> r.getVis().get()).average();
+            if(visAvg.isPresent())
+                visAvg = OptionalDouble.of((double)Math.round(visAvg.getAsDouble()));
+
+            var newIds = new ArrayList<Integer>();
+            var surveyMethodBlocks = surveyRows.stream().filter(r -> r.getMethodBlock() != null)
+                    .collect(Collectors.groupingBy(StagedRowFormatted::getMethodBlock));
+
+            for(var methodBlockRows : surveyMethodBlocks.values()) {
+
+                var firstRow = methodBlockRows.get(0);
+                var surveyNotDone = firstRow.getRef().getSpecies().equalsIgnoreCase("Survey Not Done");
+                var method = entityManager.getReference(Method.class, firstRow.getMethod());
+                var surveyMethod = SurveyMethodEntity.builder().survey(survey).method(method)
+                        .blockNum(firstRow.getBlock())
+                        .surveyNotDone(surveyNotDone).build();
+
+                // TODO: move out of the loop if we can
+                surveyMethod = surveyMethodRepository.save(surveyMethod);
+
+                for (var row : methodBlockRows) {
+
+                    var diver = row.getDiver();
+
+                    var measures = row.getMeasureJson();
+
+                    if (!surveyNotDone && row.getInverts() != null && row.getInverts() > 0)
+                        measures.put(0, row.getInverts());
+
+                    var observations = new ArrayList<Observation>();
+
+                    for (var m : measures.entrySet()) {
+
+                        var measureTypeId = MeasureType.FishSizeClass;
+
+                        switch (method.getMethodId()) {
+                            case SurveyMethod.M3:
+                                measureTypeId = MeasureType.InSituQuadrat;
+                                break;
+                            case SurveyMethod.M4:
+                                measureTypeId = MeasureType.MacrocystisBlock;
+                                break;
+                            case SurveyMethod.M5:
+                                measureTypeId = MeasureType.LimpetQuadrat;
+                                break;
+                            case SurveyMethod.M12:
+                                measureTypeId = MeasureType.SingleItem;
+                                break;
+                            default:
+                                measureTypeId = MeasureType.FishSizeClass;
+                        }
+
+                        if (speciesMethods.contains(method.getMethodId())) {
+
+                            if (job.getIsExtendedSize() && row.getIsInvertSizing())
+                                measureTypeId = MeasureType.InvertSizeClass;
+
+                            var obsItemType = row.getSpecies().get().getObsItemType();
+                            if (obsItemType.getObsItemTypeId() == ObservableItemType.NoSpeciesFound)
+                                measureTypeId = MeasureType.Absence;
+
+                        }
+
+                        var measure = measureRepository.findByMeasureTypeIdAndSeqNo(measureTypeId, m.getKey())
+                                .orElse(null);
+
+                        var observation = Observation.builder()
+                                .diver(diver)
+                                .surveyMethod(surveyMethod)
+                                .observableItem(row.getSpecies().get())
+                                .measure(measure)
+                                .measureValue(m.getValue())
+                                .build();
+
+                        observations.add(observation);
+                    }
+
+                    var newObservations = observationRepository.saveAll(observations);
                     newIds.addAll(newObservations.stream().map(o -> o.getObservationId()).collect(Collectors.toList()));
-                });
-            });
-            messages.add("Insert Observation IDs: " + formatRange(newIds));
-            messages.add("Update Survey ID: " + surveyId);
-            return surveyId;
-        }).collect(Collectors.toList());
+                }
 
-        stagedJobLogRepository.save(
-                StagedJobLog.builder()
-                        .stagedJob(job)
-                        .details(messages.stream().collect(Collectors.joining("\n")))
-                        .eventType(StagedJobEventType.CORRECTED)
-                        .build());
+                messages.add("Insert Observation IDs: " + formatRange(newIds));
+                messages.add("Update Survey ID: " + surveyId);
+            }
+        }
+
+        //TODO: set survey last updated and save new vis avg
+        var details = messages.stream().collect(Collectors.joining("\n"));
+        var log = StagedJobLog.builder().stagedJob(job).details(details).eventType(StagedJobEventType.CORRECTED);
+        stagedJobLogRepository.save(log.build());
         job.setStatus(StatusJobType.CORRECTED);
         job.setSurveyIds(surveyIds);
         jobRepository.save(job);

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
@@ -63,9 +63,6 @@ public class SurveyCorrectionService {
     SiteRepository siteRepository;
 
     @Autowired
-    EntityManager entityManager;
-
-    @Autowired
     ObservationRepository observationRepository;
 
     @Autowired
@@ -160,7 +157,7 @@ public class SurveyCorrectionService {
 
                 var firstRow = methodBlockRows.get(0);
                 var surveyNotDone = firstRow.getRef().getSpecies().equalsIgnoreCase("Survey Not Done");
-                var method = entityManager.getReference(Method.class, firstRow.getMethod());
+                var method = methodRepository.getReferenceById(firstRow.getMethod());
                 var surveyMethod = SurveyMethodEntity.builder().survey(survey).method(method)
                         .blockNum(firstRow.getBlock())
                         .surveyNotDone(surveyNotDone).build();

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -108,14 +108,6 @@ public class SurveyIngestionService {
                         .build()));
     }
 
-    public SurveyMethodEntity getSurveyMethod(Survey survey, StagedRowFormatted stagedRow) {
-        boolean surveyNotDone = stagedRow.getRef().getSpecies().equalsIgnoreCase("Survey Not Done");
-        Method method = entityManager.getReference(Method.class, stagedRow.getMethod());
-        SurveyMethodEntity surveyMethod = SurveyMethodEntity.builder().survey(survey).method(method).blockNum(stagedRow.getBlock())
-                .surveyNotDone(surveyNotDone).build();
-        return surveyMethodRepository.save(surveyMethod);
-    }
-
     public List<Observation> getObservations(SurveyMethodEntity surveyMethod, StagedRowFormatted stagedRow,
             Boolean withExtendedSizing) {
         if (!stagedRow.getSpecies().isPresent())
@@ -178,6 +170,14 @@ public class SurveyIngestionService {
         return surveyRows.stream().filter(r -> r.getMethodBlock() != null).collect(Collectors.groupingBy(StagedRowFormatted::getMethodBlock));
     }
 
+    public SurveyMethodEntity getSurveyMethod(Survey survey, StagedRowFormatted stagedRow) {
+        boolean surveyNotDone = stagedRow.getRef().getSpecies().equalsIgnoreCase("Survey Not Done");
+        Method method = entityManager.getReference(Method.class, stagedRow.getMethod());
+        SurveyMethodEntity surveyMethod = SurveyMethodEntity.builder().survey(survey).method(method).blockNum(stagedRow.getBlock())
+                .surveyNotDone(surveyNotDone).build();
+        return surveyMethodRepository.save(surveyMethod);
+    }
+    
     @Transactional
     public void ingestTransaction(StagedJob job, Collection<StagedRowFormatted> validatedRows) {
 

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
@@ -256,7 +256,7 @@ public class SurveyValidation {
         return res;
     }
 
-    private Collection<SurveyValidationError> checkSurveyGroups(ProgramValidation validation, Boolean isExtended,
+    private Collection<SurveyValidationError> checkSurveyGroups(ProgramValidation validation,
             Map<String, List<StagedRowFormatted>> surveyGroupMap) {
         var res = new HashSet<SurveyValidationError>();
 
@@ -308,12 +308,15 @@ public class SurveyValidation {
         return sheetErrors;
     }
 
-    public Collection<SurveyValidationError> validateSurveyGroups(ProgramValidation validation, Boolean isExtended,
+    public Collection<SurveyValidationError> validateSurveyGroups(ProgramValidation validation, Boolean isCorrection,
             Collection<StagedRowFormatted> mappedRows) {
         var sheetErrors = new HashSet<SurveyValidationError>();
 
         var surveyGroupMap = mappedRows.stream().collect(Collectors.groupingBy(StagedRowFormatted::getSurveyGroup));
-        sheetErrors.addAll(checkSurveyGroups(validation, isExtended, surveyGroupMap));
+
+        // Skip survey group validation if correcting a single survey
+        if(!isCorrection || surveyGroupMap.keySet().size() > 1)
+            sheetErrors.addAll(checkSurveyGroups(validation, surveyGroupMap));
 
         return sheetErrors;
     }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
@@ -198,7 +198,7 @@ public class ValidationProcess {
 
         sheetErrors.addAll(surveyValidation.validateSurveys(validation, job.getIsExtendedSize(), mappedRows));
         
-        sheetErrors.addAll(surveyValidation.validateSurveyGroups(validation, job.getIsExtendedSize(), mappedRows));
+        sheetErrors.addAll(surveyValidation.validateSurveyGroups(validation, false, mappedRows));
 
         response.setIncompleteSurveyCount(sheetErrors.stream().filter(e -> e.getMessage().contains("Survey incomplete")).count());
         response.setExistingSurveyCount(sheetErrors.stream().filter(e -> e.getMessage().contains("Survey exists:")).count());

--- a/api/src/main/resources/sql/application.sql
+++ b/api/src/main/resources/sql/application.sql
@@ -370,6 +370,8 @@ CREATE SEQUENCE IF NOT EXISTS nrmn.staged_job_log_id_seq;
 CREATE SEQUENCE IF NOT EXISTS nrmn.user_id_seq;
 
 ALTER SEQUENCE nrmn.staged_row_id_seq INCREMENT BY 100;
+ALTER SEQUENCE nrmn.observation_observation_id INCREMENT BY 100;
+ALTER SEQUENCE nrmn.survey_method_survey_method_id INCREMENT BY 100;
 
 CREATE UNIQUE INDEX idx_unique_ep_rarity_frequency_taxon ON nrmn.ep_rarity_frequency(taxon);
 CREATE UNIQUE INDEX idx_unique_ep_m1 ON nrmn.ep_m1(survey_id, recorded_species_name, size_class, block, "method", diver);

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import au.org.aodn.nrmn.restapi.data.model.Diver;
+import au.org.aodn.nrmn.restapi.data.model.Method;
 import au.org.aodn.nrmn.restapi.data.model.ObsItemType;
 import au.org.aodn.nrmn.restapi.data.model.ObservableItem;
 import au.org.aodn.nrmn.restapi.data.model.Observation;
@@ -35,6 +36,7 @@ import au.org.aodn.nrmn.restapi.data.model.StagedJob;
 import au.org.aodn.nrmn.restapi.data.model.StagedRow;
 import au.org.aodn.nrmn.restapi.data.model.Survey;
 import au.org.aodn.nrmn.restapi.data.repository.MeasureRepository;
+import au.org.aodn.nrmn.restapi.data.repository.MethodRepository;
 import au.org.aodn.nrmn.restapi.data.repository.ObservationRepository;
 import au.org.aodn.nrmn.restapi.data.repository.SiteRepository;
 import au.org.aodn.nrmn.restapi.data.repository.StagedJobLogRepository;
@@ -71,6 +73,9 @@ public class SurveyCorrectionServiceTest {
     @Mock
     private StagedJobLogRepository stagedJobLogRepository;
 
+    @Mock
+    private MethodRepository methodRepository;
+    
     @InjectMocks
     SurveyCorrectionService surveyCorrectionService;
 
@@ -101,7 +106,7 @@ public class SurveyCorrectionServiceTest {
                 .site(Site.builder().siteCode("A SITE").isActive(false).build()).depth(1).surveyNum(2)
                 .direction(Directions.N).vis(Optional.of(15.5)).date(LocalDate.of(2003, 03, 03))
                 .time(Optional.of(LocalTime.of(12, 34, 56))).pqs(diver).isInvertSizing(true).code("AAA")
-                .inverts(0)
+                .inverts(0).surveyId(1L)
                 .measureJson(startingMeasures)
                 .ref(ref);
     }
@@ -112,13 +117,13 @@ public class SurveyCorrectionServiceTest {
         when(surveyMethodRepository.save(any())).then(s -> s.getArgument(0));
         when(observationRepository.saveAll(any())).thenReturn(Arrays.asList(Observation.builder().observationId(0).build()));
         when(observationRepository.findObservationIdsForSurvey(any())).thenReturn(Arrays.asList(0));
-
+        when(methodRepository.getReferenceById(2)).thenReturn(new Method(2, "ASD", true));
         var correctedRow = rowBuilder.build();
         var correctedMeasures = Map.of(2, 5);
         correctedRow.setMeasureJson(correctedMeasures);
 
         try {
-            surveyCorrectionService.correctSurvey(ingestedJob, Arrays.asList(0,1,2), Arrays.asList(correctedRow));
+            surveyCorrectionService.correctSurvey(ingestedJob, Arrays.asList(1), Arrays.asList(correctedRow));
         } catch (Exception e) {
             fail(e.getMessage());
         }

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
@@ -112,7 +112,7 @@ public class SurveyCorrectionServiceTest {
     }
 
     @Test
-    void correctSurvey() {
+    void correctSingleSurvey() {
 
         when(surveyMethodRepository.save(any())).then(s -> s.getArgument(0));
         when(observationRepository.saveAll(any())).thenReturn(Arrays.asList(Observation.builder().observationId(0).build()));
@@ -134,6 +134,11 @@ public class SurveyCorrectionServiceTest {
         assertEquals(correctedMeasures.get(2), savedObservations.get(0).getMeasureValue());
 
         Mockito.verify(surveyMethodRepository).deleteForSurveyId(ingestedSurvey.getSurveyId());
+    }
+
+    @Test
+    void correctMultipleSurvey() {
+        
     }
 
     @Test

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
@@ -114,10 +114,10 @@ public class SurveyCorrectionServiceTest {
     @Test
     void correctSingleSurvey() {
 
-        when(surveyMethodRepository.save(any())).then(s -> s.getArgument(0));
         when(observationRepository.saveAll(any())).thenReturn(Arrays.asList(Observation.builder().observationId(0).build()));
-        when(observationRepository.findObservationIdsForSurvey(any())).thenReturn(Arrays.asList(0));
-        when(methodRepository.getReferenceById(2)).thenReturn(new Method(2, "ASD", true));
+        when(surveyRepository.findAllById(any())).thenReturn(Arrays.asList(ingestedSurvey));
+        when(methodRepository.findAll()).thenReturn(Arrays.asList(Method.builder().methodId(2).build()));
+
         var correctedRow = rowBuilder.build();
         var correctedMeasures = Map.of(2, 5);
         correctedRow.setMeasureJson(correctedMeasures);
@@ -133,12 +133,7 @@ public class SurveyCorrectionServiceTest {
         assertEquals(1, savedObservations.size());
         assertEquals(correctedMeasures.get(2), savedObservations.get(0).getMeasureValue());
 
-        Mockito.verify(surveyMethodRepository).deleteForSurveyId(ingestedSurvey.getSurveyId());
-    }
-
-    @Test
-    void correctMultipleSurvey() {
-        
+        Mockito.verify(surveyMethodRepository).deleteForSurveyIds(any());
     }
 
     @Test

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
@@ -118,7 +118,7 @@ public class SurveyCorrectionServiceTest {
         correctedRow.setMeasureJson(correctedMeasures);
 
         try {
-            surveyCorrectionService.correctSurvey(ingestedJob, ingestedSurvey, Arrays.asList(correctedRow));
+            surveyCorrectionService.correctSurvey(ingestedJob, Arrays.asList(0,1,2), Arrays.asList(correctedRow));
         } catch (Exception e) {
             fail(e.getMessage());
         }

--- a/db/schema-update/17-alter-seq-increment.sql
+++ b/db/schema-update/17-alter-seq-increment.sql
@@ -1,2 +1,4 @@
+BEGIN TRANSACTION;
 ALTER SEQUENCE nrmn.observation_observation_id INCREMENT BY 100;
 ALTER SEQUENCE nrmn.survey_method_survey_method_id INCREMENT BY 100;
+END TRANSACTION;

--- a/db/schema-update/17-alter-seq-increment.sql
+++ b/db/schema-update/17-alter-seq-increment.sql
@@ -1,0 +1,2 @@
+ALTER SEQUENCE nrmn.observation_observation_id INCREMENT BY 100;
+ALTER SEQUENCE nrmn.survey_method_survey_method_id INCREMENT BY 100;

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,5 +1,9 @@
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
+import ArrowForwardIosSharpIcon from '@mui/icons-material/ArrowForwardIosSharp';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
 import {responsiveFontSizes, ThemeProvider, createTheme} from '@mui/material/styles';
 import Alert from '@mui/material/Alert';
 import {LicenseManager} from 'ag-grid-enterprise';
@@ -37,15 +41,17 @@ import 'ag-grid-community/dist/styles/ag-theme-material.css';
 
 const App = () => {
   const [menuOpen, setMenuOpen] = useState(false);
-  const [auth, setAuth] = useState(JSON.parse(localStorage.getItem('auth')) || {expires: 0, username: null, features:[]});
+  const [auth, setAuth] = useState(JSON.parse(localStorage.getItem('auth')) || {expires: 0, username: null, features: []});
 
   const [applicationError, setApplicationError] = useState();
+  const [errorToggled, setErrorToggled] = useState(false);
+
   window.setApplicationError = setApplicationError;
 
   const loggedIn = Date.now() < auth.expires;
 
   const licenceKey = JSON.parse(localStorage.getItem('gridLicense'));
-  if(licenceKey) LicenseManager.setLicenseKey(licenceKey);
+  if (licenceKey) LicenseManager.setLicenseKey(licenceKey);
 
   const productionTheme = useMemo(
     () =>
@@ -58,11 +64,12 @@ const App = () => {
             table: {
               fontSize: 12,
               padding: 6
-          }},
+            }
+          },
           palette: {
             mode: 'light',
             primary: {main: '#546E7B', light: '#AADFFA', dark: '#546E7B', rowHeader: '#E4EAED', rowHighlight: '#F2F6F7'},
-            secondary: {main: '#563FF2', light: '#7D69FF', dark: '#5844DB',  rowHeader: '#E4EAED', rowHighlight: '#F2F6F7'}
+            secondary: {main: '#563FF2', light: '#7D69FF', dark: '#5844DB', rowHeader: '#E4EAED', rowHighlight: '#F2F6F7'}
           }
         })
       ),
@@ -75,8 +82,9 @@ const App = () => {
         createTheme({
           typography: {
             table: {
-              fontSize: 12,
-          }},
+              fontSize: 12
+            }
+          },
           palette: {
             mode: 'light',
             primary: {main: '#7B6154', light: '#AADFFA', dark: '#546E7B', rowHeader: '#E4EAED', rowHighlight: '#F2F6F7'},
@@ -92,23 +100,33 @@ const App = () => {
       <ThemeProvider theme={auth?.features?.includes('verification') ? verificationTheme : productionTheme}>
         <Router>
           <SideMenu open={menuOpen} onClose={() => setMenuOpen(false)}></SideMenu>
-          <TopBar onMenuClick={() => setMenuOpen(true)}>{auth?.features?.includes('verification') ? 'NRMN Verification' : 'National Reef Monitoring Network'}</TopBar>
+          <TopBar onMenuClick={() => setMenuOpen(true)}>
+            {auth?.features?.includes('verification') ? 'NRMN Verification' : 'National Reef Monitoring Network'}
+          </TopBar>
           <AppContent>
             {applicationError ? (
-              <Box m={10}>
-                <Box py={3}>
-                  <Alert severity="error" variant="filled">
-                    {applicationError}
-                    <br />
-                    The server may be experiencing problems. Please wait a moment and try again.
-                    <br />
-                    If this problem persists, please contact info@aodn.org.au.
-                  </Alert>
+              <>
+                <Box m={10}>
+                  <Box py={3}>
+                    <Alert severity="error" variant="filled">
+                      The server may be experiencing problems. Please wait a moment and try again.
+                      <br />
+                      If this problem persists, please contact info@aodn.org.au.
+                    </Alert>
+                    <Accordion disableGutters elevation={0} square expanded={errorToggled} onChange={() => setErrorToggled(!errorToggled)}>
+                      <AccordionSummary expandIcon={<ArrowForwardIosSharpIcon sx={{fontSize: '0.9rem'}} />}>
+                        <p>{applicationError?.message}</p>
+                      </AccordionSummary>
+                      <AccordionDetails>
+                        <code>{applicationError?.response?.data}</code>
+                      </AccordionDetails>
+                    </Accordion>
+                  </Box>
+                  <Button variant="outlined" onClick={() => window.location.reload()}>
+                    Refresh Page
+                  </Button>
                 </Box>
-                <Button variant="outlined" onClick={() => window.location.reload()}>
-                  Refresh Page
-                </Button>
-              </Box>
+              </>
             ) : (
               <Routes>
                 <Route path="/home" element={<Homepage />} />

--- a/web/src/App.js
+++ b/web/src/App.js
@@ -1,11 +1,4 @@
-import Box from '@mui/material/Box';
-import Button from '@mui/material/Button';
-import ArrowForwardIosSharpIcon from '@mui/icons-material/ArrowForwardIosSharp';
-import Accordion from '@mui/material/Accordion';
-import AccordionSummary from '@mui/material/AccordionSummary';
-import AccordionDetails from '@mui/material/AccordionDetails';
 import {responsiveFontSizes, ThemeProvider, createTheme} from '@mui/material/styles';
-import Alert from '@mui/material/Alert';
 import {LicenseManager} from 'ag-grid-enterprise';
 import React, {useState, useMemo} from 'react';
 import {BrowserRouter as Router, Navigate, Route, Routes} from 'react-router-dom';
@@ -38,13 +31,13 @@ import SideMenu from './components/layout/SideMenu';
 import TopBar from './components/layout/TopBar';
 import 'ag-grid-community/dist/styles/ag-grid.css';
 import 'ag-grid-community/dist/styles/ag-theme-material.css';
+import ApplicationError from './components/ui/ApplicationError';
 
 const App = () => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [auth, setAuth] = useState(JSON.parse(localStorage.getItem('auth')) || {expires: 0, username: null, features: []});
 
   const [applicationError, setApplicationError] = useState();
-  const [errorToggled, setErrorToggled] = useState(false);
 
   window.setApplicationError = setApplicationError;
 
@@ -105,28 +98,7 @@ const App = () => {
           </TopBar>
           <AppContent>
             {applicationError ? (
-              <>
-                <Box m={10}>
-                  <Box py={3}>
-                    <Alert severity="error" variant="filled">
-                      The server may be experiencing problems. Please wait a moment and try again.
-                      <br />
-                      If this problem persists, please contact info@aodn.org.au.
-                    </Alert>
-                    <Accordion disableGutters elevation={0} square expanded={errorToggled} onChange={() => setErrorToggled(!errorToggled)}>
-                      <AccordionSummary expandIcon={<ArrowForwardIosSharpIcon sx={{fontSize: '0.9rem'}} />}>
-                        <p>{applicationError?.message}</p>
-                      </AccordionSummary>
-                      <AccordionDetails>
-                        <code>{applicationError?.response?.data}</code>
-                      </AccordionDetails>
-                    </Accordion>
-                  </Box>
-                  <Button variant="outlined" onClick={() => window.location.reload()}>
-                    Refresh Page
-                  </Button>
-                </Box>
-              </>
+              <ApplicationError error={applicationError} />
             ) : (
               <Routes>
                 <Route path="/home" element={<Homepage />} />

--- a/web/src/api/api.js
+++ b/web/src/api/api.js
@@ -27,7 +27,7 @@ axiosInstance.interceptors.response.use(
       localStorage.removeItem('auth');
       window.location.reload();
     } else {
-      window.setApplicationError(error?.message || JSON.stringify(error), error);
+      window.setApplicationError(error);
       console.error({error});
     }
   }
@@ -119,16 +119,16 @@ export const getDataJob = (jobId) =>
     .then((res) => res)
     .catch((err) => err);
 
-export const getCorrections = (surveyId) =>
+export const getCorrections = (surveyIds) =>
   axiosInstance
-    .get('correction/correct?surveyIds=' + surveyId, {
+    .get('correction/correct?surveyIds=' + surveyIds, {
       validateStatus: () => true
     })
     .then((res) => res)
     .catch((err) => err);
 
-export const validateSurveyCorrection = (surveyId, bodyDto) => {
-  return axiosInstance.post('correction/validate/' + surveyId, bodyDto);
+export const validateSurveyCorrection = (surveyIds, bodyDto) => {
+  return axiosInstance.post('correction/validate?surveyIds=' + surveyIds, bodyDto);
 };
 
 export const submitSurveyCorrection = (surveyId, bodyDto) => {

--- a/web/src/api/api.js
+++ b/web/src/api/api.js
@@ -121,7 +121,7 @@ export const getDataJob = (jobId) =>
 
 export const getCorrections = (surveyId) =>
   axiosInstance
-    .get('correction/correct/' + surveyId, {
+    .get('correction/correct?surveyIds=' + surveyId, {
       validateStatus: () => true
     })
     .then((res) => res)

--- a/web/src/api/api.js
+++ b/web/src/api/api.js
@@ -131,8 +131,8 @@ export const validateSurveyCorrection = (surveyIds, bodyDto) => {
   return axiosInstance.post('correction/validate?surveyIds=' + surveyIds, bodyDto);
 };
 
-export const submitSurveyCorrection = (surveyId, bodyDto) => {
-  return axiosInstance.post('correction/correct/' + surveyId, bodyDto);
+export const submitSurveyCorrection = (surveyIds, bodyDto) => {
+  return axiosInstance.post('correction/correct?surveyIds=' + surveyIds, bodyDto);
 };
 
 export const validateJob = (jobId, completion) => {

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -349,7 +349,7 @@ const SurveyCorrect = () => {
           <Button
             onClick={onSubmit}
             variant="contained"
-            disabled={!canSubmitCorrection || !editMode || loading}
+            disabled={!editMode || loading}
             startIcon={<CloudUploadIcon />}
           >
             Submit Correction

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -7,6 +7,7 @@ import 'ag-grid-enterprise';
 import {AgGridColumn, AgGridReact} from 'ag-grid-react';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
 import {Navigate, useParams} from 'react-router-dom';
+import CloudDownloadIcon from '@mui/icons-material/CloudDownload';
 import {getCorrections, submitSurveyCorrection, validateSurveyCorrection} from '../../../api/api';
 import {allMeasurements} from '../../../common/correctionsConstants';
 import ValidationPanel from '../../import/panel/ValidationPanel';
@@ -105,22 +106,22 @@ const SurveyCorrect = () => {
       {field: 'pos', label: '', editable: false, hide: true, sort: 'asc'},
       {field: 'id', label: '', editable: false, hide: true},
       {field: 'surveyId', label: 'Survey', editable: false},
-      {field: 'diverId', label: 'Diver ID', hide: true},
       {field: 'diver', label: 'Diver'},
-      {field: 'P-Qs', label: 'PQ Diver'},
-      {field: 'siteCode', label: 'Site Code', editable: false},
-      {field: 'depth', label: 'Depth', editable: false},
-      {field: 'date', label: 'Survey Date', editable: false},
-      {field: 'time', label: 'Survey Time'},
-      {field: 'vis', label: 'Visibility'},
-      {field: 'direction', label: 'Direction'},
+      {field: 'siteCode', label: 'Site No.', editable: false},
+      {field: 'siteName', label: 'Site Name', editable: false},
       {field: 'latitude', label: 'Latitude'},
       {field: 'longitude', label: 'Longitude'},
-      {field: 'observableItemId', hide: true},
-      {field: 'species', label: 'Species Name'},
+      {field: 'date', label: 'Date', editable: false},
+      {field: 'vis', label: 'Vis'},
+      {field: 'direction', label: 'Direction'},
+      {field: 'time', label: 'Time'},
+      {field: 'P-Qs', label: 'P-Qs'},
+      {field: 'depth', label: 'Depth', editable: false},
       {field: 'method', label: 'Method'},
       {field: 'block', label: 'Block'},
-      {field: 'isInvertSizing', label: 'Use Invert Sizing'},
+      {field: 'code', label: 'Code'},
+      {field: 'species', label: 'Species'},
+      {field: 'commonName', label: 'Common Name'},
       {field: 'inverts', label: 'Inverts'}
     ];
   }, []);
@@ -340,18 +341,18 @@ const SurveyCorrect = () => {
             Reset Filter
           </Button>
         </Box>
+        <Box m={1} ml={0}>
+          <Button variant="outlined" onClick={() => eh.onClickExcelExport(gridApi, 'Export', true)} startIcon={<CloudDownloadIcon />}>
+            Export
+          </Button>
+        </Box>
         <Box p={1} minWidth={120}>
           <Button onClick={onValidate} variant="contained" disabled={!editMode || loading} startIcon={<PlaylistAddCheckOutlinedIcon />}>
             Validate
           </Button>
         </Box>
         <Box p={1} minWidth={180}>
-          <Button
-            onClick={onSubmit}
-            variant="contained"
-            disabled={!editMode || loading}
-            startIcon={<CloudUploadIcon />}
-          >
+          <Button onClick={onSubmit} variant="contained" disabled={!editMode || loading} startIcon={<CloudUploadIcon />}>
             Submit Correction
           </Button>
         </Box>
@@ -412,6 +413,7 @@ const SurveyCorrect = () => {
             const field = `measurements.${idx + 1}`;
             return <AgGridColumn editable field={field} headerComponent={SurveyMeasurementHeader} key={idx} width={35} />;
           })}
+          <AgGridColumn field="isInvertSizing" headerName="Use Invert Sizing" cellEditor="agTextCellEditor" />
         </AgGridReact>
       </Box>
       <Box display={editMode ? 'none' : 'flex'} justifyContent="center">

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -1,5 +1,5 @@
 import {CloudUpload as CloudUploadIcon, PlaylistAddCheckOutlined as PlaylistAddCheckOutlinedIcon} from '@mui/icons-material/';
-import {Box, Button, Typography} from '@mui/material';
+import {Alert, Box, Button, Typography} from '@mui/material';
 import UndoIcon from '@mui/icons-material/Undo';
 import ResetIcon from '@mui/icons-material/LayersClear';
 import 'ag-grid-community/dist/styles/ag-theme-material.css';
@@ -48,6 +48,7 @@ const SurveyCorrect = () => {
   const gridRef = useRef();
 
   // FUTURE: useReducer
+  const [error, setError] = useState();
   const [editMode, setEditMode] = useState(true);
   const [rowData, setRowData] = useState();
   const [gridApi, setGridApi] = useState();
@@ -211,7 +212,10 @@ const SurveyCorrect = () => {
   const onGridReady = ({api}) => {
     getCorrections(surveyId).then((res) => {
       api.hideOverlay();
-      if (res.status !== 200) return;
+      if (res.status !== 200) {
+        setError(res.data);
+        return;
+      }
       const {rows, programValidation} = res.data;
       const unpackedData = rows.map((data, idx) => {
         const measurements = data.observationIds === '' ? {} : JSON.parse(data.measureJson);
@@ -261,7 +265,6 @@ const SurveyCorrect = () => {
     setLoading(true);
     const api = gridRef.current.api;
     const context = api.gridOptionsWrapper.gridOptions.context;
-    // context.rowData = [...rowData];
     context.useOverlay = 'Validating Survey Correction...';
     api.showLoadingOverlay();
     setSideBar(defaultSideBar);
@@ -300,6 +303,15 @@ const SurveyCorrect = () => {
   const canSubmitCorrection = validationResult && validationResult.filter((res) => res.levelId === 'BLOCKING').length < 1;
 
   if (redirect) return <Navigate push to={redirect} />;
+
+  if (error)
+    return (
+      <Box m={2}>
+        <Alert severity="error" variant="filled">
+          {error}
+        </Alert>
+      </Box>
+    );
 
   return (
     <>

--- a/web/src/components/import/DataSheetEventHandlers.js
+++ b/web/src/components/import/DataSheetEventHandlers.js
@@ -251,7 +251,8 @@ class DataSheetEventHandlers {
     requiredColumns.forEach((x) => {
       // Get the row display name from the fields, this is because we turn on skipColumnHeaders so that
       // we can add empty row, '' is used to force type to string.
-      headers.push({data: {value: '' + api.getColumnDefs().filter((y) => y.field === x)[0].headerName, type: 'String'}});
+      const column = api.getColumnDefs().filter((y) => y.field === x)[0]?.headerName;
+      if(column) headers.push({data: {value: '' + column, type: 'String'}});
     });
 
     api.exportDataAsExcel({

--- a/web/src/components/job/JobView.js
+++ b/web/src/components/job/JobView.js
@@ -57,11 +57,16 @@ const JobView = () => {
               {['STAGED', 'INGESTED'].includes(job.status) && (
                 <>
                   <Button disabled={!existsOnS3} variant="outlined" onClick={() => downloadZip(job.id, job.reference)}>
-                    {existsOnS3 ? 'Download' : 'File not found'}
+                    {existsOnS3 ? 'View uploaded XLSX' : 'File not found'}
                   </Button>{' '}
                   <Button variant="outlined" component="a" href={`/data/job/${id}/edit`} clickable>
-                    {['INGESTED'].includes(job.status) ? 'View' : 'Edit'} Sheet
-                  </Button>
+                    {['INGESTED'].includes(job.status) ? 'View ingested ' : 'Edit'} Sheet
+                  </Button>{' '}
+                  {job.surveyIds?.length > 0 && (
+                    <Button variant="outlined" component="a" onClick={() => setRedirect(true)} clickable>
+                      Correct Job Surveys
+                    </Button>
+                  )}
                 </>
               )}
             </Box>
@@ -117,11 +122,6 @@ const JobView = () => {
                     {job.surveyIds.map((id) => (
                       <Chip key={id} style={{margin: 5}} label={id} component="a" href={`/data/survey/${id}`} clickable />
                     ))}
-                  </Grid>
-                  <Grid container xs={12}>
-                    <Button variant="outlined" component="a" onClick={() => setRedirect(true)} clickable>
-                      Correct
-                    </Button>
                   </Grid>
                 </Grid>
               ) : (

--- a/web/src/components/job/JobView.js
+++ b/web/src/components/job/JobView.js
@@ -13,12 +13,14 @@ import TableRow from '@mui/material/TableRow';
 import FileDownload from 'js-file-download';
 import React, {useEffect, useState} from 'react';
 import {useParams} from 'react-router';
+import {Navigate} from 'react-router-dom';
 import {getEntity, originalJobFile} from '../../api/api';
 import EntityContainer from '../containers/EntityContainer';
 
 const JobView = () => {
   const {id} = useParams();
   const [job, setJob] = useState();
+  const [redirect, setRedirect] = useState(false);
   const [existsOnS3, setExistsOnS3] = useState(true);
 
   const downloadZip = (jobId, fileName) => {
@@ -37,6 +39,11 @@ const JobView = () => {
     }
     if (id) fetchJob();
   }, [id]);
+
+  if (redirect) {
+    const url = `/data/survey/${job.surveyIds.join(',')}/correct`;
+    return <Navigate to={url} />;
+  }
 
   return (
     <EntityContainer name="Jobs" goBackTo="/data/jobs">
@@ -110,6 +117,11 @@ const JobView = () => {
                     {job.surveyIds.map((id) => (
                       <Chip key={id} style={{margin: 5}} label={id} component="a" href={`/data/survey/${id}`} clickable />
                     ))}
+                  </Grid>
+                  <Grid container xs={12}>
+                    <Button variant="outlined" component="a" onClick={() => setRedirect(true)} clickable>
+                      Correct
+                    </Button>
                   </Grid>
                 </Grid>
               ) : (

--- a/web/src/components/ui/ApplicationError.js
+++ b/web/src/components/ui/ApplicationError.js
@@ -1,0 +1,42 @@
+import React, {useState} from 'react';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import ArrowForwardIosSharpIcon from '@mui/icons-material/ArrowForwardIosSharp';
+import Accordion from '@mui/material/Accordion';
+import AccordionSummary from '@mui/material/AccordionSummary';
+import AccordionDetails from '@mui/material/AccordionDetails';
+import Alert from '@mui/material/Alert';
+import {PropTypes} from 'prop-types';
+
+const ApplicationError = ({error}) => {
+  const [errorToggled, setErrorToggled] = useState(false);
+
+  return (
+    <Box m={10}>
+      <Box py={3}>
+        <Alert severity="error" variant="filled">
+          The server may be experiencing problems. Please wait a moment and try again.
+          <br />
+          If this problem persists, please contact info@aodn.org.au.
+        </Alert>
+        <Accordion disableGutters elevation={0} square expanded={errorToggled} onChange={() => setErrorToggled(!errorToggled)}>
+          <AccordionSummary expandIcon={<ArrowForwardIosSharpIcon sx={{fontSize: '0.9rem'}} />}>
+            <p>{error?.message}</p>
+          </AccordionSummary>
+          <AccordionDetails>
+            <code>{error?.response?.data}</code>
+          </AccordionDetails>
+        </Accordion>
+      </Box>
+      <Button variant="outlined" onClick={() => window.location.reload()}>
+        Refresh Page
+      </Button>
+    </Box>
+  );
+};
+
+export default ApplicationError;
+
+ApplicationError.propTypes = {
+  error: PropTypes.object
+};


### PR DESCRIPTION
Implements the ability to correct multiple surveys at once.
- Adds a 'Correct Job Surveys' button to the Job screen
- Add missing unvalidate columns to the corrections sheet so that the UI matches ingest
- Use batching for inserting observations and survey methods
- Refactor the MeasureType conversion from an inline switch to a static method
- Refactor the Application Error into a seperate component
- Update existing tests

Also rewrites the correction rows query which was not summing the observations when performing the row aggregate. So for identical rows with observations in the same size class only the first count was being returned instead of summing all the counts.

After merging this PR requires the script `db/schema-update/17-alter-seq-increment.sql` to be run on the DB otherwise ingest and corrections will fail with pkey error.