### PR TITLE
Group correction confirmation messages by group

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/security/JwtTokenProvider.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/security/JwtTokenProvider.java
@@ -92,7 +92,7 @@ public class JwtTokenProvider {
         } catch (MalformedJwtException ex) {
             logger.error("Invalid JWT token");
         } catch (ExpiredJwtException ex) {
-            logger.error("Expired JWT token");
+            logger.info("Expired JWT token");
         } catch (UnsupportedJwtException ex) {
             logger.error("Unsupported JWT token");
         } catch (DecodingException ex) {

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -341,16 +341,14 @@ const SurveyCorrect = () => {
     const context = api.gridOptionsWrapper.gridOptions.context;
 
     const edited = context.rowData.reduce((acc, r) => {
-      
       const rowPos = context.rowPos.indexOf(r.pos) + 1;
       const original = context.originalData.find((o) => o.id === r.id);
 
       if (!original) {
         acc.push({row: rowPos, message: 'Row inserted'});
         return acc;
-
       }
-      
+
       var messages = [];
 
       for (var key of Object.keys(r)) {
@@ -400,7 +398,6 @@ const SurveyCorrect = () => {
 
     const diff = [];
     Object.keys(grouped).forEach((k) => {
-      
       const v = grouped[k];
       const isContinuous = v.reduce((acc, r, idx) => {
         if (idx === 0) return true;

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -341,13 +341,18 @@ const SurveyCorrect = () => {
     const context = api.gridOptionsWrapper.gridOptions.context;
 
     const edited = context.rowData.reduce((acc, r) => {
+      
       const rowPos = context.rowPos.indexOf(r.pos) + 1;
       const original = context.originalData.find((o) => o.id === r.id);
+
       if (!original) {
         acc.push({row: rowPos, message: 'Row inserted'});
         return acc;
+
       }
+      
       var messages = [];
+
       for (var key of Object.keys(r)) {
         if (typeof r[key] === 'object') {
           const mmOriginal = removeNullProperties(original[key]);
@@ -386,7 +391,27 @@ const SurveyCorrect = () => {
       return acc;
     }, []);
 
-    setSurveyDiff([...edited, ...deleted]);
+    const grouped = [...edited, ...deleted].reduce((acc, r) => {
+      const message = r.message;
+      if (!acc[message]) acc[message] = [];
+      acc[message].push(r.row);
+      return acc;
+    }, {});
+
+    const diff = [];
+    Object.keys(grouped).forEach((k) => {
+      
+      const v = grouped[k];
+      const isContinuous = v.reduce((acc, r, idx) => {
+        if (idx === 0) return true;
+        if (r - v[idx - 1] === 1) return acc;
+        return false;
+      }, true);
+      const asRange = v.length > 1 && isContinuous;
+      diff.push({message: k, row: asRange ? `${v[0]}-${v[v.length - 1]}` : v.join(',')});
+    });
+
+    setSurveyDiff(diff);
   };
 
   const onSubmit = async () => {
@@ -544,7 +569,7 @@ const SurveyCorrect = () => {
           {canSubmitCorrection ? (
             <>
               <Box>
-                <Typography variant="h5">Confirm Survey Correction?</Typography>
+                <Typography variant="h5">Confirm Survey Data Correction?</Typography>
               </Box>
               <Box border={0} borderColor="grey" p={2} margin={3}>
                 <TableContainer classes={classes} component={Paper} disabled>


### PR DESCRIPTION
If the same change has been made to multiple contiguous rows then display just one message with a range as the row value instead of a different message for each change.

Also log JWT expired token at Info not Error so it isn't reported by SumoLogic.