### PR TITLE
Survey Data Lock

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -264,7 +264,6 @@ public class CorrectionController {
     @Operation(security = { @SecurityRequirement(name = "bearer-key") })
     public ResponseEntity<?> getSurveyCorrections(@RequestParam("surveyIds") List<Integer> surveyIds) {
 
-        // are any surveys locked?
         var lockedSurveys = surveyRepository.findAllById(surveyIds).stream()
                 .filter(s -> s.getLocked() != null && s.getLocked())
                 .collect(Collectors.toList());
@@ -425,7 +424,7 @@ public class CorrectionController {
 
         var survey = surveyOptional.get();
 
-        if (survey.getLocked())
+        if (survey.getLocked() != null && survey.getLocked())
             return ResponseEntity.badRequest().body("Deletion Failed. Survey is locked.");
 
         if (survey.getPqCatalogued() != null && survey.getPqCatalogued())

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/Survey.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/Survey.java
@@ -112,6 +112,11 @@ public class Survey {
     private Boolean pqCatalogued;
 
     @Basic
+    @Column(name = "locked")
+    @Schema(title = "Locked")
+    private Boolean locked;
+
+    @Basic
     @Column(name = "pq_zip_url")
     @Schema(title = "PQ zip url")
     private String pqZipUrl;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/SurveyListView.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/SurveyListView.java
@@ -22,7 +22,7 @@ import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
 @Audited(withModifiedFlag = false)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Subselect(
-        "SELECT s.survey_id, sr.site_code, to_char(s.survey_date, 'yyyy-MM-dd') as survey_date, " +
+        "SELECT s.survey_id, s.locked, sr.site_code, to_char(s.survey_date, 'yyyy-MM-dd') as survey_date, " +
                 "       (s.depth || '.' || s.survey_num) as depth, sr.site_name, pr.program_name, " +
                 "       lr.location_name, CAST((s.pq_catalogued IS TRUE) as varchar) as pq_catalogued, COALESCE(sr.mpa, '') as mpa, " +
                 "       d.diver as full_name, d.method, meo.ecoregion, sr.country, sr.state, d.species, " +
@@ -49,6 +49,10 @@ public class SurveyListView {
     @Column(name = "survey_id")
     @Audited(targetAuditMode = NOT_AUDITED)
     private Integer surveyId;
+
+    @Column(name = "locked")
+    @Audited(targetAuditMode = NOT_AUDITED)
+    private Boolean locked;
 
     @Column(name = "site_code")
     @Audited(targetAuditMode = NOT_AUDITED)
@@ -114,6 +118,12 @@ public class SurveyListView {
     public Integer getSurveyId() {
         return surveyId;
     }
+
+    @JsonGetter
+    public Boolean getLocked() {
+        return locked;
+    }
+
 
     @JsonGetter
     public String getSiteCode() {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/SiteRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/SiteRepository.java
@@ -50,5 +50,5 @@ public interface SiteRepository
             "FROM nrmn.site_ref sr " +
             "WHERE ST_DWithin(CAST(st_makepoint(sr.longitude, sr.latitude) AS geography), CAST(st_makepoint(:longitude, :latitude) AS geography), 200) " +
             "AND (sr.site_id <> :siteId)")
-    List<String> sitesWithin200m(Integer siteId, double longitude, double latitude);
+    List<String> sitesWithin200m(@Param("siteId") Integer siteId, @Param("longitude") double longitude, @Param("latitude") double latitude);
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/survey/SurveyDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/survey/SurveyDto.java
@@ -36,6 +36,7 @@ public class SurveyDto {
     private String pqDiver;
     private String pqDiverInitials;
     private Boolean blockAbundanceSimulated;
+    private Boolean locked;
     private String projectTitle;
     private String surveyNotDone;
     private String locationName;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
@@ -109,6 +109,9 @@ public class SurveyCorrectionService {
     private void surveyDeletionTransaction(StagedJob job, Survey survey, Collection<StagedRowFormatted> validatedRows) {
         var messages = new ArrayList<String>();
 
+        if (survey.getLocked())
+            throw new RuntimeException("Cannot delete a survey with locked data");
+
         // Remove existing observations
         var surveyId = survey.getSurveyId();
         messages.add("Delete Observation IDs: " + observationsForSurveySummary(surveyId));
@@ -167,6 +170,9 @@ public class SurveyCorrectionService {
 
         surveyMethodRepository.deleteForSurveyIds(surveyIds);
         var surveys = surveyRepository.findAllById(surveyIds);
+
+        if (surveys.stream().anyMatch(s -> s.getLocked()))
+            throw new RuntimeException("Cannot correct locked survey data");
 
         for (var survey : surveys) {
             messages.add("Correcting Survey ID: " + survey.getSurveyId());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
@@ -109,7 +109,7 @@ public class SurveyCorrectionService {
     private void surveyDeletionTransaction(StagedJob job, Survey survey, Collection<StagedRowFormatted> validatedRows) {
         var messages = new ArrayList<String>();
 
-        if (survey.getLocked())
+        if (survey.getLocked() != null && survey.getLocked())
             throw new RuntimeException("Cannot delete a survey with locked data");
 
         // Remove existing observations
@@ -171,7 +171,7 @@ public class SurveyCorrectionService {
         surveyMethodRepository.deleteForSurveyIds(surveyIds);
         var surveys = surveyRepository.findAllById(surveyIds);
 
-        if (surveys.stream().anyMatch(s -> s.getLocked()))
+        if (surveys.stream().anyMatch(s -> s.getLocked() != null && s.getLocked()))
             throw new RuntimeException("Cannot correct locked survey data");
 
         for (var survey : surveys) {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionService.java
@@ -93,6 +93,7 @@ public class SurveyIngestionService {
 
         return existingSurvey.orElseGet(() -> surveyRepository.save(
                 Survey.builder()
+                        .locked(false)
                         .depth(stagedRow.getDepth())
                         .surveyNum(stagedRow.getSurveyNum())
                         .direction(stagedRow.getDirection() != null ? stagedRow.getDirection().toString() : null)

--- a/api/src/main/resources/sql/application.sql
+++ b/api/src/main/resources/sql/application.sql
@@ -382,3 +382,6 @@ ALTER TABLE nrmn.survey_aud ADD COLUMN created_mod BOOLEAN;
 ALTER TABLE nrmn.survey ADD COLUMN updated TIMESTAMP;
 ALTER TABLE nrmn.survey_aud ADD COLUMN updated TIMESTAMP;
 ALTER TABLE nrmn.survey_aud ADD COLUMN updated_mod BOOLEAN;
+ALTER TABLE nrmn.survey ADD COLUMN locked BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE nrmn.survey_aud ADD COLUMN locked BOOLEAN;
+ALTER TABLE nrmn.survey_aud ADD COLUMN locked_mod BOOLEAN;

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/SurveyTestData.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/SurveyTestData.java
@@ -44,6 +44,7 @@ public class SurveyTestData {
 
     public Survey buildWith(int itemNumber) {
         return Survey.builder()
+                .locked(false)
                 .program(programTestData.buildWith(itemNumber))
                 .site(siteTestData.buildWith(itemNumber))
                 .surveyDate(Date.valueOf(date.plusDays(itemNumber)))
@@ -60,6 +61,7 @@ public class SurveyTestData {
 
     public SurveyBuilder defaultBuilder() {
         return Survey.builder()
+                     .locked(false)
                      .program(programTestData.persistedProgram())
                      .site(siteTestData.persistedSite())
                      .surveyDate(Date.valueOf("2004-11-21"))

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
@@ -96,8 +96,8 @@ public class SurveyCorrectionServiceTest {
         var diver = Diver.builder().initials("SAM").build();
         var obsItemType = ObsItemType.builder().obsItemTypeId(1).build();
         var observableItem = ObservableItem.builder().obsItemType(obsItemType).observableItemName("THE SPECIES").build();
-        ingestedSurvey = Survey.builder().surveyId(1).build();
-        lockedSurvey = Survey.builder().surveyId(2).locked(true).build();
+        ingestedSurvey = Survey.builder().locked(false).surveyId(1).build();
+        lockedSurvey = Survey.builder().locked(true).surveyId(2).build();
         ingestedJob = StagedJob.builder().id(1L).program(program).build();
 
         startingMeasures = Map.of(1, 4, 3, 7);

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionServiceTest.java
@@ -84,7 +84,7 @@ public class SurveyCorrectionServiceTest {
 
     StagedRowFormatted.StagedRowFormattedBuilder rowBuilder;
     Map<Integer, Integer> startingMeasures;
-    Survey ingestedSurvey;
+    Survey ingestedSurvey, lockedSurvey;
     StagedJob ingestedJob;
 
     @BeforeEach
@@ -97,6 +97,7 @@ public class SurveyCorrectionServiceTest {
         var obsItemType = ObsItemType.builder().obsItemTypeId(1).build();
         var observableItem = ObservableItem.builder().obsItemType(obsItemType).observableItemName("THE SPECIES").build();
         ingestedSurvey = Survey.builder().surveyId(1).build();
+        lockedSurvey = Survey.builder().surveyId(2).locked(true).build();
         ingestedJob = StagedJob.builder().id(1L).program(program).build();
 
         startingMeasures = Map.of(1, 4, 3, 7);
@@ -145,5 +146,37 @@ public class SurveyCorrectionServiceTest {
             fail(e.getMessage());
         }
         Mockito.verify(surveyRepository, times(1)).deleteById(1);
+    }
+
+
+    @Test
+    void correctLockedSurveyFailed() {
+
+        when(surveyRepository.findAllById(any())).thenReturn(Arrays.asList(lockedSurvey));
+
+        var correctedRow = rowBuilder.build();
+        var correctedMeasures = Map.of(2, 5);
+        correctedRow.setMeasureJson(correctedMeasures);
+
+        try {
+            surveyCorrectionService.correctSurvey(ingestedJob, Arrays.asList(1), Arrays.asList(correctedRow));
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "Cannot correct locked survey data");
+            return;
+        }
+
+        fail("Should have thrown an exception");
+    }
+
+    @Test
+    void deleteLockedsurveyFails() {
+        try {
+            surveyCorrectionService.deleteSurvey(ingestedJob, lockedSurvey, Arrays.asList());
+        } catch (Exception e) {
+            assertEquals(e.getMessage(), "Cannot delete a survey with locked data");
+            return;
+        }
+
+        fail("Should have thrown an exception");
     }
 }

--- a/db/schema-update/01-survey-lock.sql
+++ b/db/schema-update/01-survey-lock.sql
@@ -1,0 +1,6 @@
+-- add boolean column 'locked' to survey used to determine if a survey can be used in the corrections process
+BEGIN TRANSACTION;
+ALTER TABLE nrmn.survey ADD COLUMN locked BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE nrmn.survey_aud ADD COLUMN locked BOOLEAN;
+ALTER TABLE nrmn.survey_aud ADD COLUMN locked_mod BOOLEAN;
+END TRANSACTION;

--- a/db/schema-update/01-survey-lock.sql
+++ b/db/schema-update/01-survey-lock.sql
@@ -3,4 +3,22 @@ BEGIN TRANSACTION;
 ALTER TABLE nrmn.survey ADD COLUMN locked BOOLEAN NOT NULL DEFAULT FALSE;
 ALTER TABLE nrmn.survey_aud ADD COLUMN locked BOOLEAN;
 ALTER TABLE nrmn.survey_aud ADD COLUMN locked_mod BOOLEAN;
+
+UPDATE nrmn.survey s
+SET locked = true
+FROM (SELECT DISTINCT sm.survey_id
+      FROM nrmn.observation o RIGHT JOIN nrmn.survey_method sm on o.survey_method_id = sm.survey_method_id
+      WHERE o.observation_attribute -> 'Notes' IS NOT NULL
+         OR o.observation_attribute -> 'SizeRaw' IS NOT NULL
+         OR o.observation_attribute -> 'DescriptiveName' IS NOT NULL
+         OR o.observation_attribute -> 'SizeClassRaw' IS NOT NULL
+         OR o.observation_attribute -> 'LegalSize' IS NOT NULL
+         OR o.observation_attribute -> 'SizeEstimated' IS NOT NULL
+         OR o.observation_attribute -> 'SpeciesSex' IS NOT NULL
+         OR o.observation_attribute -> 'SimulatedAbsence' IS NOT NULL
+         OR o.observation_attribute -> 'SizeClassEstimated' IS NOT NULL
+         OR o.observation_attribute -> 'NonStandardData' IS NOT NULL
+         OR sm.survey_method_attribute -> 'LegacyMethod' IS NOT NULL) su
+where su.survey_id = s.survey_id;
+
 END TRANSACTION;

--- a/web/src/components/data-entities/survey/SurveyEdit.js
+++ b/web/src/components/data-entities/survey/SurveyEdit.js
@@ -121,16 +121,18 @@ const SurveyEdit = () => {
         onClose={() => setConfirmDelete(false)}
         onConfirm={onDelete}
       />
-      <Box m={2} display="flex" flexDirection="row" width="100%">
-        <Box flexGrow={1}>
-          <Typography variant="h4">Edit Survey Metadata</Typography>
-        </Box>
-        <Box display="flex" flexDirection="row">
-          <AuthContext.Consumer>
+      <Box m={2} display="flex" flexDirection="column" width="100%">
+        <Box display="flex" flexDirection="row" width="100%">
+          <Box flexGrow={1}>
+            <Typography variant="h4">Edit Survey Metadata</Typography>
+          </Box>
+          <Box display="flex" flexDirection="row">
+            <AuthContext.Consumer>
               {({auth}) =>
                 auth?.features?.includes('corrections') && (
                   <Box>
                     <Button
+                      disabled={item.locked === true}
                       variant="outlined"
                       startIcon={<Construction />}
                       onClick={() => setRedirect({to: `/data/survey/${surveyId}/correct`})}
@@ -140,14 +142,25 @@ const SurveyEdit = () => {
                   </Box>
                 )
               }
-          </AuthContext.Consumer>
-          <Box ml={1}>
-            <Button variant="outlined" color="error" startIcon={<Delete />} onClick={() => setConfirmDelete(true)}>
-              Delete Survey
-            </Button>
+            </AuthContext.Consumer>
+            <Box ml={1}>
+              <Button
+                variant="outlined"
+                disabled={item.locked === true}
+                color="error"
+                startIcon={<Delete />}
+                onClick={() => setConfirmDelete(true)}
+              >
+                Delete Survey
+              </Button>
+            </Box>
           </Box>
         </Box>
+        <Box display="flex" flexDirection="row-reverse" width="100%">
+            <Typography variant="button">🔒 Survey data are locked</Typography>
+        </Box>
       </Box>
+
       <Grid container direction="column" justifyContent="flex-start" alignItems="center">
         {surveyId && Object.keys(item).length === 0 ? (
           <CircularProgress size={20} />

--- a/web/src/components/data-entities/survey/SurveyList.js
+++ b/web/src/components/data-entities/survey/SurveyList.js
@@ -143,7 +143,7 @@ const SurveyList = () => {
                 tooltipValueGetter={() => 'Correct Survey'}
                 resizable={false}
                 sortable={false}
-                checkboxSelection={true}
+                checkboxSelection={(e) => e.data?.locked !== true}
                 cellStyle={{paddingLeft: '10px', color: 'grey', cursor: 'pointer'}}
                 onCellClicked={(e) => {
                   if (e.event.ctrlKey) {
@@ -202,8 +202,7 @@ const SurveyList = () => {
             <AgGridColumn flex={1} field="state" colId="survey.state" />
             <AgGridColumn flex={1} field="ecoregion" colId="survey.ecoregion" />
             <AgGridColumn flex={1} field="locationName" colId="survey.locationName" />
-            <AgGridColumn flex={1} field="species" colId="survey.species"
-                          tooltipValueGetter={(param) => param.value} />
+            <AgGridColumn flex={1} field="species" colId="survey.species" tooltipValueGetter={(param) => param.value} />
           </AgGridReact>
         </>
       )}


### PR DESCRIPTION
- Add a boolean `locked` column to the `survey` table that if true will prevent any corrections being performed on survey data as well as prevent that survey from being deleted. 
- Set the value of this column to correspond to the output of @bpasquer's query from the backlog issue.
- For locked surveys hide the select checkbox in the Survey List to prevent the survey from being added to a corrections job
- Also display the message "Survey data are locked" on the Survey Metadata Edit page
- Update unit tests.