### PR TITLE
Survey Lock Fixes

### DIFF
--- a/db/schema-update/01-survey-lock.sql
+++ b/db/schema-update/01-survey-lock.sql
@@ -17,7 +17,7 @@ FROM (SELECT DISTINCT sm.survey_id
          OR o.observation_attribute -> 'SpeciesSex' IS NOT NULL
          OR o.observation_attribute -> 'SimulatedAbsence' IS NOT NULL
          OR o.observation_attribute -> 'SizeClassEstimated' IS NOT NULL
-         OR o.observation_attribute -> 'NonStandardData' IS NOT NULL
+         OR sm.survey_method_attribute -> 'NonStandardData' IS NOT NULL
          OR sm.survey_method_attribute -> 'LegacyMethod' IS NOT NULL) su
 where su.survey_id = s.survey_id;
 

--- a/web/src/components/data-entities/survey/SurveyEdit.js
+++ b/web/src/components/data-entities/survey/SurveyEdit.js
@@ -156,9 +156,9 @@ const SurveyEdit = () => {
             </Box>
           </Box>
         </Box>
-        <Box display="flex" flexDirection="row-reverse" width="100%">
+        {item.locked === true && <Box display="flex" flexDirection="row-reverse" width="100%">
             <Typography variant="button">🔒 Survey data are locked</Typography>
-        </Box>
+        </Box>}
       </Box>
 
       <Grid container direction="column" justifyContent="flex-start" alignItems="center">


### PR DESCRIPTION
- Fix update script as `NonStandardData` is a survey method attribute not an observable item attribute.
- Hide the locked data message from the Survey Edit page if the data is not locked.