### PR TITLE
Add location narrowing to species correction filter

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/LocationController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/LocationController.java
@@ -46,10 +46,15 @@ public class LocationController {
     private ObjectMapper objMapper;
 
     @GetMapping("/locations")
-    public ResponseEntity<?>  getLocationsWithFilters(@RequestParam(value = "sort", required = false) String sort,
-                                                                 @RequestParam(value = "filters", required = false) String filters,
-                                                                 @RequestParam(value = "page", defaultValue = "0") int page,
-                                                                 @RequestParam(value = "pageSize", defaultValue = "100") int pageSize) throws JsonProcessingException {
+    public ResponseEntity<?> getLocationsWithFilters(@RequestParam(value = "sort", required = false) String sort,
+            @RequestParam(value = "filters", required = false) String filters,
+            @RequestParam(value = "all", defaultValue = "false") Boolean all,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "pageSize", defaultValue = "100") int pageSize) throws JsonProcessingException {
+
+        if (all) {
+            return ResponseEntity.ok(locationListRepository.findAll());
+        }
 
         // RequestParam do not support json object parsing automatically
         List<Filter> f = FilterCondition.parse(objMapper, filters, Filter[].class);
@@ -80,7 +85,7 @@ public class LocationController {
     @GetMapping("/location/{id}")
     public ResponseEntity<?> getLocation(@PathVariable Integer id) {
         var lOptional = locationRepository.findById(id);
-        if(!lOptional.isPresent())
+        if (!lOptional.isPresent())
             return ResponseEntity.notFound().build();
         var location = lOptional.get();
         return ResponseEntity.ok(new LocationDto(location));

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ValidationProcessIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ValidationProcessIT.java
@@ -1,14 +1,8 @@
 package au.org.aodn.nrmn.restapi.integration;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.springframework.test.util.AssertionErrors.assertEquals;
-
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
-
-import org.apache.commons.lang3.SerializationUtils;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/web/src/components/data-entities/survey/SpeciesCorrect.js
+++ b/web/src/components/data-entities/survey/SpeciesCorrect.js
@@ -82,7 +82,7 @@ const SpeciesCorrect = () => {
           });
           break;
       }
-  }, [request.request, locationData]);
+  }, [request.request, request.loading, locationData]);
 
   const detail = searchResults?.find((r) => r.observableItemId === selected?.result);
   const req = request.request;

--- a/web/src/components/data-entities/survey/SpeciesCorrect.js
+++ b/web/src/components/data-entities/survey/SpeciesCorrect.js
@@ -5,6 +5,8 @@ import {getSurveySpecies, postSpeciesCorrection} from '../../../api/api';
 import CustomSearchInput from '../../input/CustomSearchInput';
 import SpeciesCorrectFilter from './SpeciesCorrectFilter';
 import SpeciesCorrectResults from './SpeciesCorrectResults';
+import ExpandLessIcon from '@mui/icons-material/ExpandLess';
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 import LaunchIcon from '@mui/icons-material/Launch';
 
@@ -16,6 +18,7 @@ const SpeciesCorrect = () => {
   const [correction, setCorrection] = useState({newObservableItemName: null});
   const [locationData, setLocationData] = useState([]);
   const [searchResults, setSearchResults] = useState(null);
+  const [hideFilter, setHideFilter] = useState(false);
   const [selected, setSelected] = useState(null);
   const [correctionLocations, setCorrectionLocations] = useState([]);
 
@@ -47,6 +50,8 @@ const SpeciesCorrect = () => {
   }, {});
 
   useEffect(() => {
+    if (request.loading && request.request.type === 'search') setHideFilter(true);
+
     if (request.request)
       switch (request.request.type) {
         case 'search': {
@@ -86,16 +91,24 @@ const SpeciesCorrect = () => {
       <Box p={1}>
         <Typography variant="h4">Correct Species</Typography>
       </Box>
-      <SpeciesCorrectFilter
-        onLoadLocations={(locations) => setLocationData(locations)}
-        onSearch={(filter) => {
-          setSearchResults([]);
-          setSelected(null);
-          const payload = {...filter, locationIds: filter.locationId ? [filter.locationId] : filter.locationIds};
-          delete payload.locationId;
-          dispatch({type: 'getRequest', payload});
-        }}
-      />
+      <Box border={1} borderRadius={1} m={1} borderColor="divider" display="flex"  flexDirection="row">
+        <Box flex={1}>
+          <SpeciesCorrectFilter
+            display={!hideFilter}
+            onLoadLocations={(locations) => setLocationData(locations)}
+            onSearch={(filter) => {
+              setSearchResults([]);
+              setSelected(null);
+              const payload = {...filter, locationIds: filter.locationId ? [filter.locationId] : filter.locationIds};
+              delete payload.locationId;
+              dispatch({type: 'getRequest', payload});
+            }}
+          />
+        </Box>
+        <Box>
+          <IconButton onClick={() => setHideFilter(!hideFilter)}>{hideFilter ? <ExpandMoreIcon /> : <ExpandLessIcon />}</IconButton>
+        </Box>
+      </Box>
       {request.loading && <LinearProgress />}
       {request.error && <Alert severity="error">{request.error}</Alert>}
       {!request.loading && searchResults && (
@@ -182,10 +195,9 @@ const SpeciesCorrect = () => {
                       <Typography variant="caption">
                         {l.surveyIds.map((l) => (
                           <>
-                            <Link key={l} onClick={() => window.open(`/data/survey/${l}`, '_blank').focus()} href='#'>
+                            <Link key={l} onClick={() => window.open(`/data/survey/${l}`, '_blank').focus()} href="#">
                               {l}
-                            </Link>
-                            {' '}
+                            </Link>{' '}
                           </>
                         ))}
                       </Typography>

--- a/web/src/components/data-entities/survey/SpeciesCorrectFilter.js
+++ b/web/src/components/data-entities/survey/SpeciesCorrectFilter.js
@@ -41,7 +41,8 @@ const SpeciesCorrectFilter = ({display, onSearch, onLoadLocations}) => {
       await getEntity('locations?all=true').then((res) => {
         const locations = [];
         const locationIds = [];
-        res.data.filter((i) => i.status === 'Active')
+        res.data
+          .filter((i) => i.status === 'Active')
           .sort((a, b) => a.locationName.localeCompare(b.locationName))
           .forEach((d) => {
             locations[d.id] = d.locationName;
@@ -65,7 +66,7 @@ const SpeciesCorrectFilter = ({display, onSearch, onLoadLocations}) => {
         setCountries(groups.countries);
         setState(groups.areas);
 
-        const labels = res.data.items.reduce(
+        const labels = res.data.reduce(
           (acc, cur) => {
             cur.countries?.split(',').forEach((country) => {
               country = country.trim();
@@ -122,25 +123,24 @@ const SpeciesCorrectFilter = ({display, onSearch, onLoadLocations}) => {
           default:
             break;
         }
-        return updated;
       } else if (!action.value) {
         delete updated[action.field];
-      } else {
-        updated[action.field] = action.value;
-
-        const set_1 = new Set(states[updated['state']]);
-        const set_2 = new Set(countries[updated['country']]);
-        const set_3 = new Set(ecoRegions[updated['ecoRegion']]);
-
-        var intersect = new Set([...set_1, ...set_2, ...set_3]);
-        if (set_1.size > 0) intersect = new Set(Array.from(intersect).filter((i) => set_1.has(i)));
-        if (set_2.size > 0) intersect = new Set(Array.from(intersect).filter((i) => set_2.has(i)));
-        if (set_3.size > 0) intersect = new Set(Array.from(intersect).filter((i) => set_3.has(i)));
-
-        var intersect_arr = Array.from(intersect);
-        intersect_arr.filter((l) => !filter.locationIds.includes(l));
-        updated['stagedLocationIds'] = [...new Set(intersect_arr.filter((d) => d))];
       }
+      updated[action.field] = action.value;
+
+      const set_1 = new Set(states[updated['state']]);
+      const set_2 = new Set(countries[updated['country']]);
+      const set_3 = new Set(ecoRegions[updated['ecoRegion']]);
+
+      var intersect = new Set([...set_1, ...set_2, ...set_3]);
+      if (set_1.size > 0) intersect = new Set(Array.from(intersect).filter((i) => set_1.has(i)));
+      if (set_2.size > 0) intersect = new Set(Array.from(intersect).filter((i) => set_2.has(i)));
+      if (set_3.size > 0) intersect = new Set(Array.from(intersect).filter((i) => set_3.has(i)));
+
+      var intersect_arr = Array.from(intersect);
+      intersect_arr.filter((l) => !filter.locationIds.includes(l));
+      updated['stagedLocationIds'] = [...new Set(intersect_arr.filter((d) => d))];
+
       return updated;
     },
     {...initialFilter}

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -568,7 +568,7 @@ const SurveyCorrect = () => {
               <Box>
                 <Typography variant="h5">Confirm Survey Data Correction?</Typography>
               </Box>
-              <Box border={0} borderColor="grey" p={2} margin={3}>
+              <Box border={0} borderColor="divider" p={2} margin={3}>
                 <TableContainer classes={classes} component={Paper} disabled>
                   <Table>
                     <TableBody>

--- a/web/src/components/datasheets/ExtractTemplateData.js
+++ b/web/src/components/datasheets/ExtractTemplateData.js
@@ -24,10 +24,10 @@ const ExtractTemplateData = () => {
 
   useEffect(() => {
     async function fetchLocations() {
-      await getEntity('locations?pageSize=99999').then((res) => {
+      await getEntity('locations?all=true').then((res) => {
         const locations = [];
         const groups = {ecoRegions: [], countries: [], areas: [], siteCodes: []};
-        res.data.items.forEach((d) => {
+        res.data.forEach((d) => {
           locations[d.id] = d.locationName;
           ['locations', 'ecoRegions', 'countries', 'areas', 'siteCodes'].forEach((prop) => {
             d[prop]


### PR DESCRIPTION
- Implements the same location filtering as the Export CSV Template filter. Locations matching the dropdown filters will appear as a set of buttons and can either be selected individually or added all at once to the filter.
- Added feature of only showing related EcoRegions/States/Areas in the filters. eg. if an Australian ecoregion is selected then only states and areas in that ecoregion will appear in the dropdowns.
- Show/Hide filter button which hides the filter when a survey search has commenced.
- Also adds and uses an optional `all` parameter to the `locations` endpoint to defeat pagination.