### PR TITLE
Fix Add All Locations in species correct filter

### DIFF
--- a/web/src/components/data-entities/survey/SpeciesCorrectFilter.js
+++ b/web/src/components/data-entities/survey/SpeciesCorrectFilter.js
@@ -112,7 +112,7 @@ const SpeciesCorrectFilter = ({display, onSearch, onLoadLocations}) => {
       if (action.action) {
         switch (action.action) {
           case 'addAllLocations':
-            updated['locationIds'] = [...new Set(filter.stagedLocationIds.filter((d) => d))];
+            updated['locationIds'] = [...filter.locationIds, ...new Set(filter.stagedLocationIds.filter((d) => d))];
             break;
           case 'addLocation':
             updated['locationIds'] = [...filter.locationIds, action.id];


### PR DESCRIPTION
`Add All Locations` is replacing the locations not appending them