### PR TITLE
4512 improve performance

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/ObservableItemController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/ObservableItemController.java
@@ -19,10 +19,7 @@ import org.modelmapper.ModelMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Example;
-import org.springframework.data.domain.ExampleMatcher;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -69,7 +66,9 @@ public class ObservableItemController {
         List<Filter> f = FilterCondition.parse(objMapper, filters, Filter[].class);
         List<Sorter> s = FilterCondition.parse(objMapper, sort, Sorter[].class);
 
-        Page<ObservationItemListView> v = observableItemListRepository.findAllObservationItemBy(f, s, PageRequest.of(page, pageSize));
+        // Negative page size means you do not want page.
+        Pageable pages = pageSize < 0 ? Pageable.unpaged() : PageRequest.of(page, pageSize);
+        Page<ObservationItemListView> v = observableItemListRepository.findAllObservationItemBy(f, s, pages);
         Map<String, Object> data = new HashMap<>();
 
         data.put("lastRow", v.getTotalElements());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SpeciesController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/SpeciesController.java
@@ -110,4 +110,6 @@ public class SpeciesController {
          */
         return items.filter(Objects::nonNull).distinct().sorted().collect(Collectors.toCollection(ArrayList::new));
     }
+
+
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/SurveyListView.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/SurveyListView.java
@@ -25,7 +25,7 @@ import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
         "SELECT s.survey_id, s.locked, sr.site_code, to_char(s.survey_date, 'yyyy-MM-dd') as survey_date, " +
                 "       (s.depth || '.' || s.survey_num) as depth, sr.site_name, pr.program_name, " +
                 "       lr.location_name, CAST((s.pq_catalogued IS TRUE) as varchar) as pq_catalogued, COALESCE(sr.mpa, '') as mpa, " +
-                "       d.diver as full_name, d.method, meo.ecoregion, sr.country, sr.state, d.species, " +
+                "       d.diver as full_name, d.method, meo.ecoregion, sr.country, sr.state, " +
                 "       ROUND(sr.latitude::numeric, " + Iirc.ROUNDING_DIGIT + ") as latitude, " +
                 "       ROUND(sr.longitude::numeric, " + Iirc.ROUNDING_DIGIT + ") as longitude " +
                 "FROM nrmn.survey s " +
@@ -36,11 +36,9 @@ import static org.hibernate.envers.RelationTargetAuditMode.NOT_AUDITED;
                 "LEFT OUTER JOIN ( " +  // Allow missing diver with outer join
                 "    SELECT sm.survey_id, " +
                 "           string_agg(DISTINCT sm.method_id::text,', ' ORDER BY sm.method_id::text ASC) as method, " +
-                "           string_agg(DISTINCT oi.observable_item_name, ', ' ORDER BY oi.observable_item_name ASC) as species, " +
                 "           string_agg(DISTINCT dr.full_name, ', ' ORDER BY dr.full_name ASC) as diver " +
                 "    FROM nrmn.observation o " +
                 "        INNER JOIN nrmn.survey_method sm on o.survey_method_id = sm.survey_method_id " +
-                "        INNER JOIN nrmn.observable_item_ref oi on oi.observable_item_id = o.observable_item_id " +
                 "        INNER JOIN nrmn.diver_ref dr on dr.diver_id = o.diver_id " +
                 "    GROUP BY sm.survey_id) d on d.survey_id = s.survey_id"
 )
@@ -110,10 +108,6 @@ public class SurveyListView {
     @Audited(targetAuditMode = NOT_AUDITED)
     private String ecoregion;
 
-    @Column(name = "species")
-    @Audited(targetAuditMode = NOT_AUDITED)
-    private String species;
-
     @JsonGetter
     public Integer getSurveyId() {
         return surveyId;
@@ -173,11 +167,6 @@ public class SurveyListView {
     @JsonGetter
     public String getDiverName() {
         return fullName;
-    }
-
-    @JsonGetter
-    public String getSpecies() {
-        return species;
     }
 
     @JsonGetter

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/controller/ObservableItemControllerIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/controller/ObservableItemControllerIT.java
@@ -50,7 +50,7 @@ public class ObservableItemControllerIT {
     @Test
     @WithUserDetails("test@example.com")
     public void testGetObservableItemListItems() {
-        ObservableItem testObservableItem = observableItemTestData.persistedObservableItem();
+        ObservableItem testObservableItem = observableItemTestData.persistedObservableItem(observableItemTestData.defaultBuilder().build());
 
         given()
                 .spec(spec)

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/controller/SurveyControllerIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/controller/SurveyControllerIT.java
@@ -814,7 +814,7 @@ public class SurveyControllerIT {
         assertEquals(101, items.get(0).get("surveyId"));
         assertEquals(104, items.get(1).get("surveyId"));
 
-        // Noted desc ordering in test, composite filter with OR
+        // Noted desc ordering in test, composite filter and is always OR condition as in GUI
         obj = given().spec(getDataSpec)
                 .queryParam("filters", "[{\"field\":\"survey.observableItemId\",\"ops\":\"OR\",\"conditions\":[{\"ops\":\"equals\",\"val\":\"" + oi3.getObservableItemId() + "\"},{\"ops\":\"contains\",\"val\":\"" + oi6.getObservableItemId() + "\"}]}]")
                 .queryParam("sort", "[{\"field\":\"survey.surveyId\",\"order\":\"desc\"}]")

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/ObservableItemIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/ObservableItemIT.java
@@ -33,7 +33,7 @@ class ObservableItemIT {
 
     @Test
     public void testMapping() {
-        ObservableItem observableItem = observableItemTestData.persistedObservableItem();
+        ObservableItem observableItem = observableItemTestData.persistedObservableItem(observableItemTestData.defaultBuilder().build());
         entityManager.clear();
         ObservableItem persistedObservableItem = observableItemRepository.findById(observableItem.getObservableItemId()).get();
         assertEquals(observableItem.getObservableItemName(), persistedObservableItem.getObservableItemName());

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/ObservableItemTestData.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/ObservableItemTestData.java
@@ -18,9 +18,16 @@ public class ObservableItemTestData {
 
     private int observableItemNo = 0;
 
-    public ObservableItem persistedObservableItem() {
-        ObservableItem observableItem = defaultBuilder().build();
+    public ObservableItem persistedObservableItem(ObservableItem observableItem) {
         return observableItemRepository.saveAndFlush(observableItem);
+    }
+
+    public ObservableItem buildWith(int itemNumber, String itemName) {
+        return ObservableItem.builder()
+                .observableItemName("Obs" + itemNumber)
+                .obsItemType(obsItemTypeTestData.persistedObsItemType())
+                .speciesEpithet(itemName)
+                .build();
     }
 
     public ObservableItemBuilder defaultBuilder() {

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/ObservationTestData.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/ObservationTestData.java
@@ -39,7 +39,7 @@ public class ObservationTestData {
     }
 
     public Observation buildWith(SurveyMethodEntity enitity, Diver diver, ObservableItem oi, int itemNumber) {
-        final Map<String, String> observationAttribute = new HashMap<String, String>();
+        final Map<String, String> observationAttribute = new HashMap<>();
         observationAttribute.put("Item Number", String.valueOf(itemNumber));
         return Observation.builder()
                 .surveyMethod(enitity)
@@ -53,7 +53,7 @@ public class ObservationTestData {
     }
 
     public ObservationBuilder defaultBuilder() {
-        final Map<String, String> observationAttribute = new HashMap<String, String>();
+        final Map<String, String> observationAttribute = new HashMap<>();
         observationAttribute.put("Biomass", "0.7630353218");
         return Observation.builder()
             .diver(diverTestData.persistedDiver())

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/ObservationTestData.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/model/db/ObservationTestData.java
@@ -3,6 +3,7 @@ package au.org.aodn.nrmn.restapi.model.db;
 import java.util.HashMap;
 import java.util.Map;
 
+import au.org.aodn.nrmn.restapi.data.model.ObservableItem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -32,13 +33,18 @@ public class ObservationTestData {
         return observation;
     }
 
+
     public Observation buildWith(SurveyMethodEntity enitity, Diver diver, int itemNumber) {
+        return buildWith(enitity, diver, null, itemNumber);
+    }
+
+    public Observation buildWith(SurveyMethodEntity enitity, Diver diver, ObservableItem oi, int itemNumber) {
         final Map<String, String> observationAttribute = new HashMap<String, String>();
         observationAttribute.put("Item Number", String.valueOf(itemNumber));
         return Observation.builder()
                 .surveyMethod(enitity)
                 .diver(diver)
-                .observableItem(observableItemTestData.persistedObservableItem())
+                .observableItem(observableItemTestData.persistedObservableItem(oi == null ? observableItemTestData.defaultBuilder().build() : oi))
                 .measure(measureTestData.persistedMeasure())
                 .measureValue(itemNumber)
                 .observationAttribute(observationAttribute)
@@ -51,7 +57,7 @@ public class ObservationTestData {
         observationAttribute.put("Biomass", "0.7630353218");
         return Observation.builder()
             .diver(diverTestData.persistedDiver())
-            .observableItem(observableItemTestData.persistedObservableItem())
+            .observableItem(observableItemTestData.persistedObservableItem(observableItemTestData.defaultBuilder().build()))
             .measure(measureTestData.persistedMeasure())
             .measureValue(4)
             .observationAttribute(observationAttribute);

--- a/web/src/components/data-entities/survey/SurveyList.js
+++ b/web/src/components/data-entities/survey/SurveyList.js
@@ -345,6 +345,7 @@ const SurveyList = () => {
               headerName="Survey ID"
               colId="survey.surveyId"
               sort="desc"
+              sortable="false"
               cellStyle={{cursor: 'pointer'}}
               onCellClicked={(e) => {
                 if (e.event.ctrlKey) {


### PR DESCRIPTION
Run a bit faster now, from the explain plan, the most costly part is still the string_agg (for diver and method)

->  GroupAggregate  (cost=484002.59..520016.13 rows=29870 width=68)
"                                Output: sm.survey_id, string_agg(DISTINCT (sm.method_id)::text, ', '::text ORDER BY (sm.method_id)::text), string_agg(DISTINCT (dr.full_name)::text, ', '::text ORDER BY (dr.full_name)::text)"
                                Group Key: sm.survey_id

No species by default and hidden until you expand the filter. Max two species filter allowed