### PR TITLE
Skip tests when building on Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
                 stage('build') {
                     steps {
                         sh 'yarn --cwd web --frozen-lockfile'
-                        sh 'mvn --batch-mode --threads 2 clean package'
+                        sh 'mvn --batch-mode --threads 2 --define maven.test.skip=true clean package'
                     }
                 }
             }

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -16,22 +16,6 @@
         <version>3.0.0</version>
         <executions>
           <execution>
-            <id>yarn-test</id>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-            <phase>test</phase>
-            <configuration>
-              <executable>yarn</executable>
-              <arguments>
-                <argument>test</argument>
-              </arguments>
-              <environmentVariables>
-                <CI>false</CI>
-              </environmentVariables>
-            </configuration>
-          </execution>
-          <execution>
             <?m2e ignore?>
             <id>yarn-build</id>
             <goals>


### PR DESCRIPTION
Tests are run in GitHub actions so there's no need to run them on Jenkins also.
May also help reduce memory usage.