### PR TITLE
Fix filename for unfiltered CSV shared links

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/MaterializedViewService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/MaterializedViewService.java
@@ -86,7 +86,7 @@ public class MaterializedViewService {
                                 country.getRight())))
                 .collect(Collectors.toList());
 
-        var fullViewName = Objects.isNull(countries) && Objects.isNull(states) ? viewName : viewName + "_all";
+        var fullViewName = (countries.isEmpty() && states.isEmpty()) ? viewName : viewName + "_all";
         requests.add(new CSVFilterPrinter(headers, fullViewName, null, null));
 
         for (var request : requests) {


### PR DESCRIPTION
`ep_site_list.csv` is being exported as `ep_site_list_all.csv`