### PR TITLE
Store bulk species update filters

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -411,9 +411,9 @@ public class CorrectionController {
                 var summary = surveyCorrectionService.diffSurveyCorrections(surveyIds, rows);
 
                 var summaryLog = StagedJobLog.builder()
-                                .stagedJob(job)
-                                .eventType(StagedJobEventType.SUMMARY)
-                                .summary(summary).build();
+                        .stagedJob(job)
+                        .eventType(StagedJobEventType.SUMMARY)
+                        .summary(summary).build();
 
                 stagedJobLogRepository.save(summaryLog);
 
@@ -592,6 +592,14 @@ public class CorrectionController {
 
         try {
             surveyCorrectionService.correctSpecies(job, bodyDto.getSurveyIds(), curr, next);
+
+            var filterSetLog = StagedJobLog.builder()
+                    .stagedJob(job)
+                    .eventType(StagedJobEventType.FILTER)
+                    .filterSet(bodyDto.getFilterSet()).build();
+
+            stagedJobLogRepository.save(filterSetLog);
+
             materializedViewService.refreshAllAsync();
         } catch (ConstraintViolationException cv) {
             logger.error("Correction failed on update species, whole transaction rollback!", cv);

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -591,14 +591,17 @@ public class CorrectionController {
         result.put("jobId", "");
 
         try {
-            surveyCorrectionService.correctSpecies(job, bodyDto.getSurveyIds(), curr, next);
+            var count = surveyCorrectionService.correctSpecies(job, bodyDto.getSurveyIds(), curr, next);
 
-            var filterSetLog = StagedJobLog.builder()
-                    .stagedJob(job)
-                    .eventType(StagedJobEventType.FILTER)
-                    .filterSet(bodyDto.getFilterSet()).build();
+            stagedJobLogRepository.save(StagedJobLog.builder()
+            .stagedJob(job)
+            .eventType(StagedJobEventType.CORRECTING)
+            .details("Updating " + count + " observations.").build());
 
-            stagedJobLogRepository.save(filterSetLog);
+            stagedJobLogRepository.save(StagedJobLog.builder()
+            .stagedJob(job)
+            .eventType(StagedJobEventType.FILTER)
+            .filterSet(bodyDto.getFilterSet()).build());
 
             materializedViewService.refreshAllAsync();
         } catch (ConstraintViolationException cv) {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/StagedJobLog.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/StagedJobLog.java
@@ -18,6 +18,7 @@ import javax.persistence.Table;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import au.org.aodn.nrmn.restapi.dto.correction.CorrectionDiffDto;
+import au.org.aodn.nrmn.restapi.dto.correction.SpeciesSearchBodyDto;
 import au.org.aodn.nrmn.restapi.enums.StagedJobEventType;
 
 import org.hibernate.annotations.CreationTimestamp;
@@ -66,5 +67,9 @@ public class StagedJobLog {
     @Column(name = "summary", columnDefinition = "jsonb")
     @Type(type = "jsonb")
     private CorrectionDiffDto summary;
+
+    @Column(name = "filter_set", columnDefinition = "jsonb")
+    @Type(type = "jsonb")
+    private SpeciesSearchBodyDto filterSet;
 
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/ObservationRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/ObservationRepository.java
@@ -18,17 +18,23 @@ public interface ObservationRepository
 
     @Query(nativeQuery = true, value = "SELECT DISTINCT ON (species_name) observable_item_id as id, species_name as speciesName, common_name " +
             "as commonName, is_invert_sized as isInvertSized, l5, l95, maxabundance as maxAbundance, lmax " +
-            "FROM  nrmn.ui_species_attributes   where observable_item_id in :id")
+            "FROM  {h-schema}ui_species_attributes   where observable_item_id in :id")
     List<UiSpeciesAttributes> getSpeciesAttributesByIds(@Param("id") int[] id);
 
     @Query("SELECT observationId FROM Observation where surveyMethod.survey.surveyId = :surveyId AND surveyMethod.method.methodId NOT IN (6, 13) ORDER BY observationId")
     List<Integer> findObservationIdsForSurvey(@Param("surveyId") Integer surveyId);
 
+    @Query(nativeQuery = true, value = "" +
+    "select count(*) from {h-schema}observation o " +
+    "inner join {h-schema}survey_method m on m.survey_method_id = o.survey_method_id " + 
+    "where survey_id in :surveyIds and observable_item_id = :oldId")
+	Long countObservationsForSurveys(@Param("surveyIds") List<Integer> surveyIds, @Param("oldId") Integer oldId);
+
 	@Modifying
     @Query(nativeQuery = true, value = "" +
-    "update nrmn.observation " +
+    "update {h-schema}observation " +
     "set observable_item_id = :newId " +
-    "from nrmn.survey_method " +
+    "from {h-schema}survey_method " +
     "where observation.survey_method_id = survey_method.survey_method_id " +
     "and observable_item_id = :oldId and survey_id = :surveyId")
 	void updateObservableItemsForSurveys(@Param("surveyId") Integer surveyId, @Param("oldId") Integer oldId, @Param("newId") Integer newId);

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/SpeciesCorrectBodyDto.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/dto/correction/SpeciesCorrectBodyDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 @Data
 @NoArgsConstructor
 public class SpeciesCorrectBodyDto {
+    private SpeciesSearchBodyDto filterSet;
     private Integer prevObservableItemId;
     private Integer newObservableItemId;
     private List<Integer> surveyIds;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/enums/StagedJobEventType.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/enums/StagedJobEventType.java
@@ -2,16 +2,12 @@ package au.org.aodn.nrmn.restapi.enums;
 
 public enum StagedJobEventType {
     UPLOADED,
-    VALIDATING,
-    STAGING,
     STAGED,
-    EDITING,
     INGESTING,
     CORRECTING,
     INGESTED,
     CORRECTED,
-    DELETED,
-    ABANDONED,
     ERROR,
-    SUMMARY
+    SUMMARY,
+    FILTER
 }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/SurveyCorrectionService.java
@@ -253,8 +253,10 @@ public class SurveyCorrectionService {
         surveyCorrectionTransaction(job, surveyIds, validatedRows);
     }
 
-    public void correctSpecies(StagedJob job, List<Integer> surveyIds, ObservableItem curr, ObservableItem next) throws JsonProcessingException {
+    public Long correctSpecies(StagedJob job, List<Integer> surveyIds, ObservableItem curr, ObservableItem next) throws JsonProcessingException {
+        var count = observationRepository.countObservationsForSurveys(surveyIds, curr.getObservableItemId());
         speciesCorrectionTransaction(job, surveyIds, curr, next);
+        return count;
     }
 
     public void deleteSurvey(StagedJob job, Survey survey, Collection<StagedRowFormatted> validatedRows) {

--- a/api/src/main/resources/sql/application.sql
+++ b/api/src/main/resources/sql/application.sql
@@ -251,6 +251,7 @@ CREATE TABLE nrmn.staged_job_log (
     staged_job_id bigint NOT NULL,
     survey_id INT,
     summary JSONB,
+    filter_set JSONB,
     CONSTRAINT staged_job_log_pkey PRIMARY KEY (id)
 );
 

--- a/db/schema-update/01-add-staged-log-surveyid-summary.sql
+++ b/db/schema-update/01-add-staged-log-surveyid-summary.sql
@@ -2,8 +2,10 @@ BEGIN TRANSACTION;
 
 ALTER TABLE nrmn.staged_job_log DROP COLUMN IF EXISTS survey_id;
 ALTER TABLE nrmn.staged_job_log DROP COLUMN IF EXISTS summary;
+ALTER TABLE nrmn.staged_job_log DROP COLUMN IF EXISTS filter_set;
 
 ALTER TABLE nrmn.staged_job_log ADD COLUMN survey_id INT;
 ALTER TABLE nrmn.staged_job_log ADD COLUMN summary JSONB;
+ALTER TABLE nrmn.staged_job_log ADD COLUMN filter_set JSONB;
 
 END TRANSACTION

--- a/web/src/components/data-entities/survey/SpeciesCorrectEdit.js
+++ b/web/src/components/data-entities/survey/SpeciesCorrectEdit.js
@@ -136,10 +136,11 @@ const SpeciesCorrectEdit = ({selected, onSubmit, onError}) => {
                 disabled={!correction?.newObservableItemName || correction.surveyIds.length < 1}
                 onClick={() => {
                   setLoading(true);
-                  postSpeciesCorrection(correction)
+                  const postDto = {...correction, filterSet: selected.filter};
+                  postSpeciesCorrection(postDto)
                     .then((res) => {
                       if(res.status === 200) {
-                        setCorrection({ ...initialCorrectionState });
+                        setCorrection({ ...initialCorrectionState});
                         onSubmit(res.data);
                       }
                     })

--- a/web/src/components/job/JobView.js
+++ b/web/src/components/job/JobView.js
@@ -168,6 +168,7 @@ const JobView = ({jobId}) => {
                             ))}
                             {log.summary && <SurveyDiff surveyDiff={log.summary} />}
                           </Typography>
+                          {log.filterSet && Object.keys(log.filterSet).map((v,i) => (log.filterSet[v] ? <TableRow><TableCell>{v}</TableCell><TableCell>{log.filterSet[v]}</TableCell></TableRow> : <></>))}
                         </TableCell>
                       </TableRow>
                     ))}

--- a/web/src/components/job/JobView.js
+++ b/web/src/components/job/JobView.js
@@ -168,7 +168,7 @@ const JobView = ({jobId}) => {
                             ))}
                             {log.summary && <SurveyDiff surveyDiff={log.summary} />}
                           </Typography>
-                          {log.filterSet && Object.keys(log.filterSet).map((v,i) => (log.filterSet[v] ? <TableRow><TableCell>{v}</TableCell><TableCell>{log.filterSet[v]}</TableCell></TableRow> : <></>))}
+                          {log.filterSet && Object.keys(log.filterSet).map((v) => (log.filterSet[v] ? <TableRow><TableCell>{v}</TableCell><TableCell>{log.filterSet[v]}</TableCell></TableRow> : <></>))}
                         </TableCell>
                       </TableRow>
                     ))}


### PR DESCRIPTION
- Extend the StagedJobLog to include filters
- Also log the count of the observations changes
- Display the filters in a basic format if present on the job.