### PR TITLE
Remove empty cells when pasting

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,9 +5,22 @@
       "label": "React Dev Server",
       "type": "shell",
       "isBackground": true,
-      "problemMatcher": ["$eslint-stylish"],
-      "command": "yarn --cwd ${workspaceFolder}/web && yarn --cwd ${workspaceFolder}/web --ignore-pattern '**/node_modules/*' start",
-      "options": { "env": { "BROWSER": "none" } }
+      "group": "build",
+      "problemMatcher": [
+        "$eslint-stylish"
+      ],
+      "command": "yarn && BROWSER=none yarn start",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": true
+      },
+      "options": {
+          "cwd": "${workspaceFolder}/web"
+      }
     }
   ]
 }

--- a/web/src/components/data-entities/survey/SpeciesCorrectErrorResults.js
+++ b/web/src/components/data-entities/survey/SpeciesCorrectErrorResults.js
@@ -52,10 +52,10 @@ const SpeciesCorrectErrorResults = ({correctionErrors}) => {
         <TableBody>
           { correctionErrors.surveyIds.length > 0 ? (
               correctionErrors.surveyIds.map((r) => (
-                <TableRow key={'surveyid-' + r} style={{ cursor: 'pointer' }} onClick={() => window.open(`/data/survey/${r}/edit`, '_blank').focus()}>
+                <TableRow key={'surveyid-' + r} style={{ cursor: 'pointer' }}>
                   <TableCell>{correctionErrors.currentSpeciesName}</TableCell>
                   <TableCell>{correctionErrors.nextSpeciesName}</TableCell>
-                  <TableCell>{r}</TableCell>
+                  <TableCell onClick={() => window.open(`/data/survey/${r}/edit`, '_blank').focus()} style={{textDecoration: 'underline dotted'}}>{r}</TableCell>
                 </TableRow>
               ))
           ) : (

--- a/web/src/components/data-entities/survey/SurveyCorrect.js
+++ b/web/src/components/data-entities/survey/SurveyCorrect.js
@@ -432,6 +432,7 @@ const SurveyCorrect = () => {
           onPasteStart={eh.onPasteStart}
           onRowDataUpdated={onRowDataUpdated}
           onSortChanged={eh.onSortChanged}
+          processDataFromClipboard={eh.processDataFromClipboard}
           ref={gridRef}
           rowHeight={20}
           rowSelection="multiple"

--- a/web/src/components/import/DataSheetEventHandlers.js
+++ b/web/src/components/import/DataSheetEventHandlers.js
@@ -556,6 +556,10 @@ class DataSheetEventHandlers {
     this.onClearRegion(e);
   }
 
+  processDataFromClipboard(params) {
+    return params.data.filter(d => (d.length === 1 && d[0] !== ''));
+  }
+
   handlePasteEnd(e) {
     const context = e.api.gridOptionsWrapper.gridOptions.context;
     context.pasteMode = false;

--- a/web/src/components/import/DataSheetView.js
+++ b/web/src/components/import/DataSheetView.js
@@ -373,6 +373,7 @@ const DataSheetView = ({onIngest, isAdmin}) => {
             onPasteStart={eh.onPasteStart}
             onRowDataUpdated={onRowDataUpdated}
             onSortChanged={eh.onSortChanged}
+            processDataFromClipboard={eh.processDataFromClipboard}
             rowHeight={20}
             rowSelection="multiple"
             sideBar={sideBar}


### PR DESCRIPTION
When copying a species name from the Observable Item table it sometimes includes spurious leading carriage return, leading to a paste with an empty cell followed by the species name. This PR will just remove empty cells from the paste data.