### PR TITLE
Allow NONE validation for unattached survey ingest

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -248,7 +248,8 @@ public class CorrectionController {
             validation.add(surveyValidation.validateDateRange(programValidation, row), false);
 
             // Site distance validation
-            validation.add(siteValidation.validateSurveyAtSite(row));
+            if(programValidation != ProgramValidation.NONE)
+                validation.add(siteValidation.validateSurveyAtSite(row));
         }
 
         surveyValidation.validateSurveysMatch(surveyIds, mappedRows).forEach(surveyMatchError -> {

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/SurveyDtoMapperConfig.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/mapping/SurveyDtoMapperConfig.java
@@ -13,6 +13,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 @Configuration
@@ -49,8 +50,13 @@ public class SurveyDtoMapperConfig {
                 surveyMethodRepository.findDiversForSurvey(ctx.getSource()));
         Converter<String, String> passThrough = ctx -> Optional.ofNullable(ctx.getSource()).orElse("");
 
-        Converter<Site, String> toSiteLatitude = ctx -> Double.parseDouble(String.format("%.5f", ctx.getSource().getLatitude())) + "";
-        Converter<Site, String> toSiteLongitude = ctx -> Double.parseDouble(String.format("%.5f", ctx.getSource().getLongitude())) + "";
+        Converter<Site, String> toSiteLatitude = ctx -> {
+            return Objects.nonNull(ctx.getSource().getLatitude()) ? Double.parseDouble(String.format("%.5f", ctx.getSource().getLatitude())) + "" : "";
+        };
+
+        Converter<Site, String> toSiteLongitude = ctx -> {
+            return Objects.nonNull(ctx.getSource().getLongitude()) ? Double.parseDouble(String.format("%.5f", ctx.getSource().getLongitude())) + "" : "";
+        };
 
         modelMapper.typeMap(Survey.class, SurveyDto.class).addMappings(mapper -> {
             mapper.using(toSiteLatitude).map(Survey::getSite, SurveyDto::setSiteLatitude);

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/generator/SurveyIdentifierGenerator.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/generator/SurveyIdentifierGenerator.java
@@ -1,0 +1,39 @@
+package au.org.aodn.nrmn.restapi.data.generator;
+
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.id.IdentifierGenerator;
+
+import au.org.aodn.nrmn.restapi.data.model.Survey;
+
+import java.io.Serializable;
+import java.sql.SQLException;
+
+public class SurveyIdentifierGenerator implements IdentifierGenerator {
+
+    @Override
+    public Serializable generate(SharedSessionContractImplementor session, Object object) throws HibernateException {
+        var sequence = "nrmn.survey_survey_id";
+        if (object instanceof Survey) {
+            var survey = (Survey)object;
+            if (survey.getProgram().getProgramId() == 0)
+                sequence = "nrmn.survey_survey_id_m0";
+        } else {
+            throw new HibernateException("Unsupported entity for this identifier generator");
+        }
+
+        var connection = session.connection();
+        try {
+            var preparedStatement = connection.prepareStatement("SELECT nextval(?)");
+            preparedStatement.setString(1, sequence);
+            var resultSet = preparedStatement.executeQuery();
+            if (resultSet.next()) {
+                return resultSet.getInt(1);
+            }
+        } catch (SQLException e) {
+            throw new HibernateException("Error generating identifier", e);
+        }
+
+        throw new HibernateException("Unable to generate identifier");
+    }
+}

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/Survey.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/model/Survey.java
@@ -11,6 +11,7 @@ import java.util.List;
 import javax.persistence.*;
 
 import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.envers.Audited;
 
@@ -34,8 +35,8 @@ import lombok.Setter;
 @Audited(withModifiedFlag = true)
 public class Survey {
     @Id
-    @SequenceGenerator(name = "survey_survey_id", sequenceName = "survey_survey_id", allocationSize = 1)
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "survey_survey_id")
+    @GeneratedValue(generator = "SurveyIdentifierGenerator")
+    @GenericGenerator(name = "SurveyIdentifierGenerator", strategy = "au.org.aodn.nrmn.restapi.data.generator.SurveyIdentifierGenerator")
     @Column(name = "survey_id", unique = true, updatable = false, nullable = false)
     @Schema(title = "Id")
     private Integer surveyId;

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/DataValidation.java
@@ -116,7 +116,8 @@ public class DataValidation {
             var rowId = row.getId();
 
             // Site
-            if (row.getSiteCode() == null || !siteCodes.contains(row.getSiteCode().toLowerCase()))
+            if ((validation != ProgramValidation.NONE)
+                    && (row.getSiteCode() == null || !siteCodes.contains(row.getSiteCode().toLowerCase())))
                 errors.add(rowId, ValidationLevel.BLOCKING, "siteCode", "Site Code does not exist");
 
             // Diver

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/SurveyValidation.java
@@ -285,7 +285,7 @@ public class SurveyValidation {
                     && res.stream().anyMatch(e -> e != null && e.getMessage().contains("Survey exists:"));
 
             // VALIDATION: Survey Complete
-            if (!surveyExistsM3) {
+            if (!surveyExistsM3 && validation != ProgramValidation.NONE) {
                 res.add(validateSurveyComplete(validation, surveyRows));
             }
         }

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/validation/ValidationProcess.java
@@ -89,7 +89,8 @@ public class ValidationProcess {
             results.add(surveyValidation.validateDateRange(validation, row), false);
 
             // Validate survey is at site location
-            results.add(siteValidation.validateSurveyAtSite(row));
+            if(validation != ProgramValidation.NONE)
+                results.add(siteValidation.validateSurveyAtSite(row));
         }
 
         var res = new HashSet<SurveyValidationError>();

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/service/SurveyIngestionServiceTest.java
@@ -78,7 +78,7 @@ public class SurveyIngestionServiceTest {
     void init() {
 
         StagedRow ref = StagedRow.builder()
-                .stagedJob(StagedJob.builder().program(Program.builder().programName("PROJECT").build()).build())
+                .stagedJob(StagedJob.builder().program(Program.builder().programName("PROJECT").programId(1).build()).build())
                 .build();
 
         Diver diver = Diver.builder().initials("SAM").build();
@@ -95,7 +95,11 @@ public class SurveyIngestionServiceTest {
     void getSurveyForNewSurvey() {
         when(surveyRepository.save(any())).then(s -> s.getArgument(0));
         when(siteRepo.save(any())).then(s -> s.getArgument(0));
-        Survey survey = surveyIngestionService.getSurvey(new Program(), OptionalDouble.of(15.5), rowBuilder.build());
+
+        var row = rowBuilder.build();
+
+        var survey = surveyIngestionService.getSurvey(row.getRef().getStagedJob().getProgram(), OptionalDouble.of(15.5), row);
+
         assertEquals(1, survey.getDepth());
         assertEquals(2, survey.getSurveyNum());
         assertEquals("A SITE", survey.getSite().getSiteCode());
@@ -114,14 +118,14 @@ public class SurveyIngestionServiceTest {
         when(surveyRepository.save(any())).then(s -> s.getArgument(0));
         when(siteRepo.save(any())).then(s -> s.getArgument(0));
 
-        StagedRowFormatted row1 = rowBuilder.build();
+        var row = rowBuilder.build();
 
-        Survey survey1 = surveyIngestionService.getSurvey(new Program(), OptionalDouble.empty(), row1);
+        var survey1 = surveyIngestionService.getSurvey(row.getRef().getStagedJob().getProgram(), OptionalDouble.empty(), row);
 
-        StagedRowFormatted row2 = rowBuilder.block(2).method(1)
+        var row2 = rowBuilder.block(2).method(1)
                 .measureJson(ImmutableMap.<Integer, Integer>builder().put(1, 4).put(3, 7).build()).build();
 
-        Survey survey2 = surveyIngestionService.getSurvey(new Program(), OptionalDouble.empty(), row2);
+        var survey2 = surveyIngestionService.getSurvey(row.getRef().getStagedJob().getProgram(), OptionalDouble.empty(), row2);
 
         assertEquals(survey1, survey2);
     }

--- a/api/src/test/resources/testdata/FILL_DATA.sql
+++ b/api/src/test/resources/testdata/FILL_DATA.sql
@@ -10,6 +10,10 @@ VALUES (55, 'RLS', True);
 INSERT INTO nrmn.program_ref(program_id, program_name, is_active)
 VALUES (56, 'ATRC', True);
 
+INSERT INTO nrmn.location_ref (location_id, location_name, is_active) VALUES (0, 'NONE', true);
+
+INSERT INTO nrmn.site_ref (site_id, site_name, site_code, location_id, is_active) VALUES (0, 'NONE', 'NONE', 0, true);
+
 INSERT INTO nrmn.site_ref(site_id, site_code, site_name, longitude, latitude, location_id, state, country,
                           old_site_code, mpa, protection_status, site_attribute, is_active)
 VALUES (551, 'EYR71', 'South East Slade Point', 154, -35, 29, 'South Australia', 'Australia', '{"4117"}',

--- a/db/schema-update/02-add-unattached-location-site.sql
+++ b/db/schema-update/02-add-unattached-location-site.sql
@@ -1,0 +1,15 @@
+begin transaction;
+
+delete from nrmn.site_ref where site_id = 0;
+
+delete from nrmn.location_ref where location_id = 0;
+
+drop SEQUENCE if EXISTS nrmn.survey_survey_id_m0;
+
+insert into nrmn.location_ref (location_id, location_name, is_active) values (0, 'NONE', true);
+
+insert into nrmn.site_ref (site_id, site_name, site_code, location_id, is_active) values (0, 'NONE', 'NONE', 0, true);
+
+CREATE SEQUENCE nrmn.survey_survey_id_m0 START WITH 903400000 INCREMENT BY 1 NO MINVALUE MAXVALUE 923399999 CACHE 1;
+
+end;

--- a/web/src/components/import/JobUpload.js
+++ b/web/src/components/import/JobUpload.js
@@ -93,7 +93,7 @@ const JobUpload = () => {
                   <Box p={3}>
                     <Button
                       variant="contained"
-                      disabled={!formData.file || !formData.programId}
+                      disabled={!formData.file || isNaN(formData.programId)}
                       style={{width: '100%'}}
                       onClick={() =>
                         submitJobFile(formData, setUploadProgress).then(({response}) =>


### PR DESCRIPTION
- add dummy site and location
- handle cases where site has no lat / long and skip validation
- when program is NONE use a difference sequence for generating surveyID and skip some use a difference sequence for generating surveyID