### PR TITLE
Prevent admin user from editing own details

### DIFF
--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/AdminController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/AdminController.java
@@ -179,6 +179,16 @@ public class AdminController {
         if (!isAdmin(authentication))
             return ResponseEntity.badRequest().body("Unauthorized");
 
+        var thisUser = userRepository.findByEmail(authentication.getName()).get();
+
+        var userId = user.getUserId();
+        var thisUserId = thisUser.getUserId();
+        if(userId.equals(thisUserId)){
+            var ret = new SecUserDto(thisUser, null);
+            ret.setError("Cannot update current user");
+            return ResponseEntity.ok(ret);
+        }
+
         var updatedUser = userRepository.getReferenceById(user.getUserId());
 
         return ResponseEntity.ok(persistUserDto(updatedUser, user));

--- a/web/src/components/admin/UserComponent.js
+++ b/web/src/components/admin/UserComponent.js
@@ -88,17 +88,19 @@ const UserComponent = ({value, onAdd}) => {
         <button onClick={() => dispatch({type: 'editMode', value: !state.editMode})}>{state.editMode ? 'Cancel' : 'Edit'}</button>
       </Box>
       <Box flex={2}>
-        {state.editMode ? (
-          <>
-            <input onChange={(e) => dispatch({type: 'userUpdate', value: {email: e.target.value}})} value={state.userUpdate.email} />
-            <br />
-            <span style={{color: 'red'}}>{state.error}</span>
-          </>
-        ) : (
-          <Typography fontSize={13} backgroundColor={state.userIsAdmin && 'yellow'} color={!state.userEnabled && 'gray'}>
-            {state.user.email}
-          </Typography>
-        )}
+        <>
+          {state.editMode ? (
+            <>
+              <input onChange={(e) => dispatch({type: 'userUpdate', value: {email: e.target.value}})} value={state.userUpdate.email} />
+              {state.error && <br />}
+            </>
+          ) : (
+            <Typography fontSize={13} backgroundColor={state.userIsAdmin && 'yellow'} color={!state.userEnabled && 'gray'}>
+              {state.user.email}
+            </Typography>
+          )}
+          <span style={{color: 'red'}}>{state.error}</span>
+        </>
       </Box>
       <Box flex={2}>
         {state.editMode ? (


### PR DESCRIPTION
Adds a blunt safety feature to user management preventing a logged in admin from deactivating their own account by mistake.