### PR TITLE
Features/6118 speedup save validation

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -61,7 +61,7 @@ jobs:
         '
 
     - name: Archive Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: war-file
         path: app/target/*.war

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/controller/CorrectionController.java
@@ -6,6 +6,7 @@ import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import au.org.aodn.nrmn.restapi.data.model.*;
 import au.org.aodn.nrmn.restapi.service.validation.*;
 import au.org.aodn.nrmn.restapi.util.SpacialUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -27,11 +28,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import au.org.aodn.nrmn.restapi.controller.mapping.StagedRowMapperConfig;
-import au.org.aodn.nrmn.restapi.data.model.ObservableItem;
-import au.org.aodn.nrmn.restapi.data.model.StagedJob;
-import au.org.aodn.nrmn.restapi.data.model.StagedJobLog;
-import au.org.aodn.nrmn.restapi.data.model.StagedRow;
-import au.org.aodn.nrmn.restapi.data.model.UiSpeciesAttributes;
 import au.org.aodn.nrmn.restapi.data.model.audit.UserActionAudit;
 import au.org.aodn.nrmn.restapi.data.repository.CorrectionRowRepository;
 import au.org.aodn.nrmn.restapi.data.repository.DiverRepository;
@@ -277,16 +273,14 @@ public class CorrectionController {
                 .filter(s -> s.getLocked() != null && s.getLocked())
                 .collect(Collectors.toList());
 
-        if (lockedSurveys.size() > 0) {
+        if (!lockedSurveys.isEmpty()) {
             var locked = lockedSurveys.stream().map(s -> s.getSurveyId().toString()).collect(Collectors.joining(", "));
             // The return type is application/json
             return ResponseEntity.badRequest()
                     .body(String.format("{ \"message\": \"Surveys are locked and cannot be corrected: %s\" }", locked));
         }
 
-        var programs = correctionRowRepository.findProgramsBySurveyIds(surveyIds)
-                .stream()
-                .collect(Collectors.toList());
+        var programs = new ArrayList<>(correctionRowRepository.findProgramsBySurveyIds(surveyIds));
 
         var programValidations = programs.stream().map(ProgramValidation::fromProgram)
                 .collect(Collectors.toList());
@@ -297,7 +291,7 @@ public class CorrectionController {
         var program = programs.get(0);
 
         var rows = correctionRowRepository.findRowsBySurveyIds(surveyIds);
-        var exists = rows != null && rows.size() > 0;
+        var exists = rows != null && !rows.isEmpty();
         var bodyDto = new CorrectionRowsDto();
         bodyDto.setRows(rows);
         bodyDto.setProgramName(program.getProgramName());

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/SiteRepository.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/data/repository/SiteRepository.java
@@ -14,6 +14,7 @@ import au.org.aodn.nrmn.restapi.data.repository.model.EntityCriteria;
 import javax.persistence.QueryHint;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import static org.hibernate.jpa.QueryHints.HINT_CACHEABLE;
@@ -28,8 +29,16 @@ public interface SiteRepository
     @QueryHints({@QueryHint(name = HINT_CACHEABLE, value = "true")})
     List<Site> findByCriteria(@Param("code") String siteCode);
 
-    @Query(value = "SELECT LOWER(siteCode) FROM Site WHERE siteCode IN :siteCodes")
-    List<String> getAllSiteCodesMatching(@Param("siteCodes") Collection<String> siteCodes);
+    default List<String> getAllSiteCodesMatching(Collection<String> siteCodes) {
+        if (siteCodes == null || siteCodes.isEmpty()) {
+            return Collections.emptyList();
+        }
+        return findSiteCodesMatching(siteCodes);
+    }
+    // Use nativeQuery to reduce the number of object create for site s, which is not necessary, always call the
+    // getAllSiteCodesMatching as it handle edge cases
+    @Query(value = "SELECT LOWER(s.site_code) FROM {h-schema}site_ref s WHERE s.site_code IN :siteCodes", nativeQuery = true)
+    List<String> findSiteCodesMatching(@Param("siteCodes") Collection<String> siteCodes);
 
     @Query("SELECT s FROM Site s")
     @QueryHints({@QueryHint(name = HINT_CACHEABLE, value = "true")})

--- a/api/src/main/java/au/org/aodn/nrmn/restapi/service/formatting/SpeciesFormattingService.java
+++ b/api/src/main/java/au/org/aodn/nrmn/restapi/service/formatting/SpeciesFormattingService.java
@@ -3,6 +3,7 @@ package au.org.aodn.nrmn.restapi.service.formatting;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import au.org.aodn.nrmn.restapi.data.model.*;
@@ -39,7 +40,7 @@ public class SpeciesFormattingService {
     public List<StagedRowFormatted> formatRowsWithSpecies(Collection<StagedRow> rows,
             Collection<ObservableItem> species) {
 
-        var rowMap = rows.stream().collect(Collectors.toMap(StagedRow::getId, r -> r));
+        Map<Long, StagedRow> rowMap = rows.stream().collect(Collectors.toMap(StagedRow::getId, r -> r));
 
         var speciesIds = species.stream()
                 .mapToInt(ObservableItem::getObservableItemId)

--- a/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ATRCSurveyGroupCompleteIT.java
+++ b/api/src/test/java/au/org/aodn/nrmn/restapi/integration/ATRCSurveyGroupCompleteIT.java
@@ -66,11 +66,11 @@ class ATRCSurveyGroupCompleteIT {
         sn1.setMethod("2");
         sn1.setSiteCode(siteNo);
         sn1.setStagedJob(job);
-        StagedRow sn2 = (StagedRow) SerializationUtils.clone(sn1);
+        StagedRow sn2 = SerializationUtils.clone(sn1);
         sn2.setDepth("7.2");
-        StagedRow sn3 = (StagedRow) SerializationUtils.clone(sn1);
+        StagedRow sn3 = SerializationUtils.clone(sn1);
         sn3.setDepth("7.3");
-        StagedRow sn4 = (StagedRow) SerializationUtils.clone(sn1);
+        StagedRow sn4 = SerializationUtils.clone(sn1);
         sn4.setDepth("7.4");
         stagedRowRepo.deleteAll();
         stagedRowRepo.saveAll(Arrays.asList(sn1, sn2, sn3, sn4));
@@ -94,10 +94,10 @@ class ATRCSurveyGroupCompleteIT {
         sn1.setSiteCode(siteNo);
         sn1.setStagedJob(job);
 
-        StagedRow sn2 = (StagedRow) SerializationUtils.clone(sn1);
+        StagedRow sn2 = SerializationUtils.clone(sn1);
         sn2.setDepth("7.2");
 
-        StagedRow sn4 = (StagedRow) SerializationUtils.clone(sn1);
+        StagedRow sn4 = SerializationUtils.clone(sn1);
         sn4.setDepth("7.4");
         stagedRowRepo.deleteAll();
 
@@ -128,22 +128,22 @@ class ATRCSurveyGroupCompleteIT {
         sn1b1.setSiteCode(siteNo);
         sn1b1.setStagedJob(job);
 
-        StagedRow sn1b2 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn1b2 =  SerializationUtils.clone(sn1b1);
         sn1b2.setBlock("2");
 
-        StagedRow sn2b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn2b1 =  SerializationUtils.clone(sn1b1);
         sn2b1.setDepth("7.2");
-        StagedRow sn2b2 = (StagedRow) SerializationUtils.clone(sn2b1);
+        StagedRow sn2b2 =  SerializationUtils.clone(sn2b1);
         sn2b2.setBlock("2");
 
-        StagedRow sn3b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn3b1 =  SerializationUtils.clone(sn1b1);
         sn3b1.setDepth("7.3");
-        StagedRow sn3b2 = (StagedRow) SerializationUtils.clone(sn3b1);
+        StagedRow sn3b2 =  SerializationUtils.clone(sn3b1);
         sn3b2.setBlock("2");
 
-        StagedRow sn4b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn4b1 =  SerializationUtils.clone(sn1b1);
         sn4b1.setDepth("7.4");
-        StagedRow sn4b2 = (StagedRow) SerializationUtils.clone(sn4b1);
+        StagedRow sn4b2 =  SerializationUtils.clone(sn4b1);
         sn4b2.setBlock("2");
 
         Location location = Location.builder().locationName("LOC1").isActive(false).build();
@@ -173,28 +173,28 @@ class ATRCSurveyGroupCompleteIT {
         sn1b1.setSiteCode(siteNo);
         sn1b1.setStagedJob(job);
 
-        StagedRow sn1b2 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn1b2 =  SerializationUtils.clone(sn1b1);
         sn1b2.setDate(date1);
         sn1b2.setBlock("2");
 
-        StagedRow sn2b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn2b1 =  SerializationUtils.clone(sn1b1);
         sn2b1.setDate(date1);
         sn2b1.setDepth("7.2");
-        StagedRow sn2b2 = (StagedRow) SerializationUtils.clone(sn2b1);
+        StagedRow sn2b2 =  SerializationUtils.clone(sn2b1);
         sn2b2.setDate(date2);
         sn2b2.setBlock("2");
 
-        StagedRow sn3b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn3b1 =  SerializationUtils.clone(sn1b1);
         sn3b1.setDate(date2);
         sn3b1.setDepth("7.3");
-        StagedRow sn3b2 = (StagedRow) SerializationUtils.clone(sn3b1);
+        StagedRow sn3b2 =  SerializationUtils.clone(sn3b1);
         sn3b2.setDate(date2);
         sn3b2.setBlock("2");
 
-        StagedRow sn4b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn4b1 =  SerializationUtils.clone(sn1b1);
         sn4b1.setDate(date2);
         sn4b1.setDepth("7.4");
-        StagedRow sn4b2 = (StagedRow) SerializationUtils.clone(sn4b1);
+        StagedRow sn4b2 =  SerializationUtils.clone(sn4b1);
         sn4b2.setBlock("2");
 
         Location location = Location.builder().locationName("LOC1").isActive(false).build();
@@ -223,21 +223,21 @@ class ATRCSurveyGroupCompleteIT {
         sn1b1.setSiteCode(siteNo);
         sn1b1.setStagedJob(job);
 
-        StagedRow sn1b2 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn1b2 =  SerializationUtils.clone(sn1b1);
         sn1b2.setBlock("2");
 
-        StagedRow sn2b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn2b1 =  SerializationUtils.clone(sn1b1);
         sn2b1.setDepth("7.2");
-        StagedRow sn2b2 = (StagedRow) SerializationUtils.clone(sn2b1);
+        StagedRow sn2b2 =  SerializationUtils.clone(sn2b1);
         sn2b2.setBlock("2");
 
-        StagedRow sn3b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn3b1 =  SerializationUtils.clone(sn1b1);
         sn3b1.setDepth("7.3");
-        StagedRow sn3b2 = (StagedRow) SerializationUtils.clone(sn3b1);
+        StagedRow sn3b2 =  SerializationUtils.clone(sn3b1);
         sn3b2.setBlock("2");
 
         // Incomplete - missing block 2
-        StagedRow sn4b1 = (StagedRow) SerializationUtils.clone(sn1b1);
+        StagedRow sn4b1 =  SerializationUtils.clone(sn1b1);
         sn4b1.setDepth("7.4");
 
         Location location = Location.builder().locationName("LOC1").isActive(false).build();


### PR DESCRIPTION
1. Simplify syntax
2. The getAll on Site is use to create a Map, so it is better to create the map in the query
3. findSiteCodesMatching is very expensive as it load Site object internally but all we need to Site code, so replace it with nativeQuery
